### PR TITLE
Scrum 167 implementar api reportar publicaciones

### DIFF
--- a/src/main/java/com/mypresentpast/backend/controller/ReportController.java
+++ b/src/main/java/com/mypresentpast/backend/controller/ReportController.java
@@ -1,0 +1,13 @@
+package com.mypresentpast.backend.controller;
+
+import com.mypresentpast.backend.dto.request.ReportRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/reports")
+public interface ReportController {
+    @PostMapping("/{postId}")
+    ResponseEntity<ApiResponse> reportPost(@PathVariable Long postId, @Valid @RequestBody ReportRequest request);
+}

--- a/src/main/java/com/mypresentpast/backend/controller/impl/ReportControllerImpl.java
+++ b/src/main/java/com/mypresentpast/backend/controller/impl/ReportControllerImpl.java
@@ -1,0 +1,23 @@
+package com.mypresentpast.backend.controller.impl;
+
+import com.mypresentpast.backend.controller.ReportController;
+import com.mypresentpast.backend.dto.request.ReportRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportControllerImpl implements ReportController {
+
+    private final ReportService reportService;
+
+    @Override
+    public ResponseEntity<ApiResponse> reportPost(Long postId, ReportRequest request) {
+        ApiResponse response = reportService.createReport(postId, request.getReason(), request.getType());
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/mypresentpast/backend/dto/request/ReportRequest.java
+++ b/src/main/java/com/mypresentpast/backend/dto/request/ReportRequest.java
@@ -1,0 +1,16 @@
+package com.mypresentpast.backend.dto.request;
+
+import com.mypresentpast.backend.enums.ReportType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ReportRequest {
+
+    @NotBlank
+    private String reason;
+
+    @NotNull
+    private ReportType type;
+}

--- a/src/main/java/com/mypresentpast/backend/enums/ReportStatus.java
+++ b/src/main/java/com/mypresentpast/backend/enums/ReportStatus.java
@@ -1,0 +1,11 @@
+package com.mypresentpast.backend.enums;
+
+/**
+ * Estado del procesamiento del reporte:
+ */
+public enum ReportStatus {
+    PENDING, // pendiente, ningún admin lo tomó.
+    IN_PROGRESS, // un admin lo está revisando.
+    ACCEPTED, // se aprueba y se debe remover la publicación (otra tarea).
+    REJECTED // se rechaza y no se hace nada.
+}

--- a/src/main/java/com/mypresentpast/backend/enums/ReportType.java
+++ b/src/main/java/com/mypresentpast/backend/enums/ReportType.java
@@ -1,0 +1,12 @@
+package com.mypresentpast.backend.enums;
+
+/**
+ * Tipos predefinidos de reporte para clasificar la razón del mismo.
+ */
+public enum ReportType {
+    SPAM,        // Contenido no deseado / promocional
+    ABUSE,       // Abuso, contenido ofensivo
+    COPYRIGHT,   // Infracción de derechos de autor
+    MISINFORMATION, // Información engañosa
+    OTHER        // Otro tipo no listado
+}

--- a/src/main/java/com/mypresentpast/backend/model/Report.java
+++ b/src/main/java/com/mypresentpast/backend/model/Report.java
@@ -1,0 +1,77 @@
+package com.mypresentpast.backend.model;
+
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.enums.ReportType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reports", uniqueConstraints = {
+        // Asegura que un usuario (reporter_id) solo pueda reportar el mismo post (post_id) una vez.
+        @UniqueConstraint(columnNames = {"post_id", "reporter_id"})
+})
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Publicación reportada. Relación ManyToOne con la entidad Post.
+     */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    /**
+     * Usuario que realiza el reporte.
+     */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id")
+    private User reporter;
+
+    /**
+     * Motivo/razón del reporte provisto por el usuario.
+     */
+    @Column(nullable = false)
+    private String reason;
+
+    /**
+     * Tipo de reporte: SPAM, ABUSE, COPYRIGHT, MISINFORMATION, OTHER.
+     * Se persiste como string para mayor legibilidad en la BD.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private ReportType type;
+
+    /**
+     * Estado del reporte en el flujo de revisión.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ReportStatus status;
+
+    /**
+     * Fecha y hora de creación del reporte. Se establece automáticamente en persist.
+     */
+    @Column(name = "created_at",nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // Se encarga de ser un inicializador para los valores por defecto de las columnas.
+    @PrePersist
+    private void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        if (this.status == null) {
+            this.status = ReportStatus.PENDING;
+        }
+    }
+}

--- a/src/main/java/com/mypresentpast/backend/model/Report.java
+++ b/src/main/java/com/mypresentpast/backend/model/Report.java
@@ -8,10 +8,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "reports", uniqueConstraints = {
-        // Asegura que un usuario (reporter_id) solo pueda reportar el mismo post (post_id) una vez.
-        @UniqueConstraint(columnNames = {"post_id", "reporter_id"})
-})
+@Table(name = "reports")
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/mypresentpast/backend/repository/ReportRepository.java
+++ b/src/main/java/com/mypresentpast/backend/repository/ReportRepository.java
@@ -1,0 +1,18 @@
+package com.mypresentpast.backend.repository;
+
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.model.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query("select count(r) > 0 from Report r where r.post.id = :postId and r.reporter.id = :reporterId and r.status in :statuses")
+    boolean existsActiveReportByPostIdAndReporterId(@Param("postId") Long postId,
+                                                    @Param("reporterId") Long reporterId,
+                                                    @Param("statuses") Collection<ReportStatus> statuses);
+
+}

--- a/src/main/java/com/mypresentpast/backend/service/ReportService.java
+++ b/src/main/java/com/mypresentpast/backend/service/ReportService.java
@@ -1,0 +1,23 @@
+package com.mypresentpast.backend.service;
+
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.enums.ReportType;
+
+public interface ReportService {
+    /**
+     * Crea un nuevo reporte para una publicación específica por parte de un usuario.
+     * * Este método implementa la lógica de negocio para asegurar que:
+     * 1. La publicación y el usuario reportador existan.
+     * 2. Un mismo usuario no pueda reportar la misma publicación más de una vez (unicidad).
+     * 3. El reporte se cree inicialmente con el estado PENDING.
+     *
+     * @param postId El ID de la publicación que está siendo reportada.
+     * @param reason La razón detallada del reporte provista por el usuario.
+     * @param type El tipo de incidente reportado (SPAM, ABUSE, etc.).
+     * @return El objeto {@code Report} recién creado y persistido.
+     * @throws com.mypresentpast.backend.exception.ResourceNotFoundException si el postId o el reporterId no existen.
+     * @throws com.mypresentpast.backend.exception.BadRequestException si ya existe un reporte previo de este usuario para la misma publicación.
+     */
+    ApiResponse createReport(Long postId, String reason, ReportType type);
+
+}

--- a/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
@@ -42,6 +42,10 @@ public class ReportServiceImpl implements ReportService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.POST_NOT_FOUND_WITH_ID, postId, reporterId)));
 
+        // Validación para evitar que el usuario reporte su propia publicación
+        if (post.getAuthor().getId().equals(reporterId)) {
+            throw new BadRequestException(String.format(MessageBundle.REPORT_SELF_POST_NOT_ALLOWED, reporterId, postId));
+        }
 
         // Validación de unicidad de negocio (Restricción de duplicidad)
         if (reportRepository.existsActiveReportByPostIdAndReporterId(postId, reporterId, EnumSet.of(ReportStatus.PENDING, ReportStatus.IN_PROGRESS))) {

--- a/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
@@ -1,0 +1,67 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.enums.ReportType;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.model.Post;
+import com.mypresentpast.backend.model.Report;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.repository.PostRepository;
+import com.mypresentpast.backend.repository.ReportRepository;
+import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.service.ReportService;
+import com.mypresentpast.backend.utils.MessageBundle;
+import com.mypresentpast.backend.utils.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
+
+    @Override
+    @Transactional
+    public ApiResponse createReport(Long postId, String reason, ReportType type) {
+
+        Long reporterId = SecurityUtils.getCurrentUserId();
+
+        // Validación y obtención del Usuario (Reportero)
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.USER_NOT_FOUND_WITH_ID, reporterId)));
+
+        // Validación y obtención de la Publicación (Post)
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.POST_NOT_FOUND_WITH_ID, postId, reporterId)));
+
+
+        // Validación de unicidad de negocio (Restricción de duplicidad)
+        if (reportRepository.existsActiveReportByPostIdAndReporterId(postId, reporterId, EnumSet.of(ReportStatus.PENDING, ReportStatus.IN_PROGRESS))) {
+            throw new BadRequestException(String.format(MessageBundle.REPORT_ALREADY_EXISTS_WITH_IDS, reporterId, postId));
+        }
+        // Construcción del Reporte
+        Report report = Report.builder()
+                .post(post)
+                .reporter(reporter)
+                .reason(reason)
+                .type(type)
+                // Asigna el estado inicial al reporte. Por defecto, cada reporte nuevo está Pendiente de revisión.
+                .status(ReportStatus.PENDING)
+                .build();
+
+        reportRepository.save(report);
+        return ApiResponse
+                .builder()
+                .message("Publicación reportada con Exito.")
+                .build();
+
+    }
+}

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -22,9 +22,7 @@ public class MessageBundle {
     public static final String LOGIN_FAILED = "Email o contraseña incorrectos";
     public static final String USER_DISABLED = "El usuario no está habilitado para iniciar sesión";
 
-
     // Profile
-    public static final String USER_NOT_FOUND_WITH_ID = "Usuario no encontrado con id [%s] ";
     public static final String AVATAR_FILE_REQUIRED = "La imagen es obligatoria para actualizar el avatar";
     public static final String AVATAR_FILE_TOO_LARGE = "La imagen seleccionada supera el tamaño máximo permitido de %d MB.";
     public static final String AVATAR_FILE_INVALID_TYPE = "El formato de la imagen no es válido. Solo se permiten archivos JPEG, PNG o WEBP.";
@@ -33,6 +31,13 @@ public class MessageBundle {
 
     // Cloudinary
     public static final String CLOUDINARY_UPLOAD_ERROR = "Ha ocurrido un error al subir la imagen a Cloudinary. Inténtalo nuevamente más tarde.";
+
+    // Reportes
+    public static final String REPORT_ALREADY_EXISTS_WITH_IDS = "El usuario con ID [%s] ya reportó la publicación con ID [%s].";
+
+    // Errores generales
+    public static final String POST_NOT_FOUND_WITH_ID = "Publicación no encontrado con id [%s] - id usuario [%s]";
+    public static final String USER_NOT_FOUND_WITH_ID = "Usuario no encontrado con id [%s] ";
 
 
     private MessageBundle() {

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -34,6 +34,7 @@ public class MessageBundle {
 
     // Reportes
     public static final String REPORT_ALREADY_EXISTS_WITH_IDS = "El usuario con ID [%s] ya reportó la publicación con ID [%s].";
+    public static final String REPORT_SELF_POST_NOT_ALLOWED = "El usuario con ID [%s] intentó reportar su propia publicación con ID [%s].";
 
     // Errores generales
     public static final String POST_NOT_FOUND_WITH_ID = "Publicación no encontrado con id [%s] - id usuario [%s]";


### PR DESCRIPTION
**Lógica de reportar publicaciones**

Se implementa la lógica para la creación de reportes en ReportControllerImpl, permitiendo a los usuarios reportar publicaciones.  
La operación utiliza el método createReport del servicio ReportService, que valida la existencia del usuario y la publicación, y evita la duplicidad de reportes activos mediante existsActiveReport.

- Se agrega el endpoint POST /reports/{postId} en ReportControllerImpl.
- Validación de usuario y publicación antes de crear el reporte.
- Restricción para evitar reportes duplicados sobre el mismo post y usuario (solo si el reporte está pendiente o en proceso).
- Respuestas claras ante errores de negocio y éxito.