### PR TITLE
SCRUM 148 api aceptar rechazar reporte

### DIFF
--- a/src/main/java/com/mypresentpast/backend/controller/AdminReportController.java
+++ b/src/main/java/com/mypresentpast/backend/controller/AdminReportController.java
@@ -1,13 +1,11 @@
 package com.mypresentpast.backend.controller;
 
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ReportListingResponse;
 import com.mypresentpast.backend.dto.response.ReportDetailResponse;
 import com.mypresentpast.backend.enums.ReportStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-
 
 /**
  * Controlador para la administración de reportes de publicaciones.
@@ -23,7 +21,6 @@ public interface AdminReportController {
      * @param pageable Parámetros de paginación y ordenamiento.
      * @return Listado paginado de reportes.
      */
-    @GetMapping
     ResponseEntity<ReportListingResponse> getReports(ReportStatus status, Pageable pageable);
 
     /**
@@ -32,6 +29,23 @@ public interface AdminReportController {
      * @param reportId ID del reporte.
      * @return Detalle del reporte.
      */
-    @GetMapping("/{reportId}")
-    ResponseEntity<ReportDetailResponse> getReportDetail(@PathVariable Long reportId);
+    ResponseEntity<ReportDetailResponse> getReportDetail(Long reportId);
+
+    /**
+     * Acepta un reporte de publicación, cambiando su estado, eliminando la publicación y registrando el administrador que lo acepta.
+     *
+     * @param reportId ID del reporte a aceptar.
+     * @param adminId ID del administrador que realiza la acción.
+     * @return Respuesta indicando el resultado de la operación.
+     */
+    ResponseEntity<ApiResponse> acceptReport(Long reportId, Long adminId);
+
+    /**
+     * Rechaza un reporte de publicación, cambiando su estado, manteniendo la publicación y registrando el administrador que lo rechaza.
+     *
+     * @param reportId ID del reporte a rechazar.
+     * @param adminId ID del administrador que realiza la acción.
+     * @return Respuesta indicando el resultado de la operación.
+     */
+    ResponseEntity<ApiResponse> rejectReport(Long reportId, Long adminId);
 }

--- a/src/main/java/com/mypresentpast/backend/controller/AdminReportController.java
+++ b/src/main/java/com/mypresentpast/backend/controller/AdminReportController.java
@@ -1,0 +1,37 @@
+package com.mypresentpast.backend.controller;
+
+import com.mypresentpast.backend.dto.response.ReportListingResponse;
+import com.mypresentpast.backend.dto.response.ReportDetailResponse;
+import com.mypresentpast.backend.enums.ReportStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+/**
+ * Controlador para la administración de reportes de publicaciones.
+ * Solo accesible para usuarios con rol ADMIN.
+ */
+public interface AdminReportController {
+
+    /**
+     * Obtiene el listado paginado de reportes de publicaciones.
+     * Permite filtrar por estado si se proporciona el parámetro.
+     *
+     * @param status Estado del reporte (opcional).
+     * @param pageable Parámetros de paginación y ordenamiento.
+     * @return Listado paginado de reportes.
+     */
+    @GetMapping
+    ResponseEntity<ReportListingResponse> getReports(ReportStatus status, Pageable pageable);
+
+    /**
+     * Obtiene el detalle de un reporte específico por su ID.
+     *
+     * @param reportId ID del reporte.
+     * @return Detalle del reporte.
+     */
+    @GetMapping("/{reportId}")
+    ResponseEntity<ReportDetailResponse> getReportDetail(@PathVariable Long reportId);
+}

--- a/src/main/java/com/mypresentpast/backend/controller/impl/AdminReportControllerImpl.java
+++ b/src/main/java/com/mypresentpast/backend/controller/impl/AdminReportControllerImpl.java
@@ -1,0 +1,38 @@
+package com.mypresentpast.backend.controller.impl;
+
+import com.mypresentpast.backend.controller.AdminReportController;
+import com.mypresentpast.backend.dto.response.ReportDetailResponse;
+import com.mypresentpast.backend.dto.response.ReportListingResponse;
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/admin/reports")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminReportControllerImpl implements AdminReportController {
+    private final ReportService reportService;
+
+    @GetMapping
+    public ResponseEntity<ReportListingResponse> getReports(
+            @RequestParam(required = false) ReportStatus status,
+            Pageable pageable) {
+        return ResponseEntity.ok(reportService.getReportListing(pageable, status));
+    }
+
+    @GetMapping("/{reportId}")
+    public ResponseEntity<ReportDetailResponse> getReportDetail(@PathVariable Long reportId) {
+        return ResponseEntity.ok(reportService.getReportDetail(reportId));
+    }
+
+}

--- a/src/main/java/com/mypresentpast/backend/controller/impl/AdminReportControllerImpl.java
+++ b/src/main/java/com/mypresentpast/backend/controller/impl/AdminReportControllerImpl.java
@@ -1,6 +1,7 @@
 package com.mypresentpast.backend.controller.impl;
 
 import com.mypresentpast.backend.controller.AdminReportController;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ReportDetailResponse;
 import com.mypresentpast.backend.dto.response.ReportListingResponse;
 import com.mypresentpast.backend.enums.ReportStatus;
@@ -9,17 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/admin/reports")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ADMIN')")
+@RequestMapping("/admin/reports")
+@PreAuthorize("hasRole('ADMIN')") // Asegura que solo los administradores puedan acceder a estos endpoints
 public class AdminReportControllerImpl implements AdminReportController {
     private final ReportService reportService;
 
@@ -35,4 +31,17 @@ public class AdminReportControllerImpl implements AdminReportController {
         return ResponseEntity.ok(reportService.getReportDetail(reportId));
     }
 
+    @PutMapping("/{reportId}/accept")
+    public ResponseEntity<ApiResponse> acceptReport(
+            @PathVariable Long reportId,
+            @RequestParam(value = "admin_id") Long adminId) {
+        return ResponseEntity.ok(reportService.acceptReport(reportId, adminId));
+    }
+
+    @PutMapping("/{reportId}/reject")
+    public ResponseEntity<ApiResponse> rejectReport(
+            @PathVariable Long reportId,
+            @RequestParam(value = "admin_id") Long adminId) {
+        return ResponseEntity.ok(reportService.rejectReport(reportId, adminId));
+    }
 }

--- a/src/main/java/com/mypresentpast/backend/dto/response/ReportDetailResponse.java
+++ b/src/main/java/com/mypresentpast/backend/dto/response/ReportDetailResponse.java
@@ -1,0 +1,21 @@
+package com.mypresentpast.backend.dto.response;
+
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.enums.ReportType;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReportDetailResponse {
+    private Long id;
+    private ReportType type;
+    private ReportStatus status;
+    private String reason;
+    private LocalDateTime createdAt;
+    private Long postId;
+    private String postName;
+    private Long reporterId;
+    private String reporterNickname;
+    private String postAuthorNickname;
+}

--- a/src/main/java/com/mypresentpast/backend/dto/response/ReportListingResponse.java
+++ b/src/main/java/com/mypresentpast/backend/dto/response/ReportListingResponse.java
@@ -1,0 +1,14 @@
+package com.mypresentpast.backend.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ReportListingResponse {
+    private List<ReportDetailResponse> reports;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/src/main/java/com/mypresentpast/backend/enums/ReportStatus.java
+++ b/src/main/java/com/mypresentpast/backend/enums/ReportStatus.java
@@ -5,7 +5,6 @@ package com.mypresentpast.backend.enums;
  */
 public enum ReportStatus {
     PENDING, // pendiente, ningún admin lo tomó.
-    IN_PROGRESS, // un admin lo está revisando.
-    ACCEPTED, // se aprueba y se debe remover la publicación (otra tarea).
+    ACCEPTED, // se aprueba y se debe remover la publicación.
     REJECTED // se rechaza y no se hace nada.
 }

--- a/src/main/java/com/mypresentpast/backend/model/Report.java
+++ b/src/main/java/com/mypresentpast/backend/model/Report.java
@@ -61,6 +61,13 @@ public class Report {
     @Column(name = "created_at",nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "decision_at")
+    private LocalDateTime decisionAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decided_by")
+    private User decidedBy;
+
     // Se encarga de ser un inicializador para los valores por defecto de las columnas.
     @PrePersist
     private void prePersist() {

--- a/src/main/java/com/mypresentpast/backend/repository/PostRepository.java
+++ b/src/main/java/com/mypresentpast/backend/repository/PostRepository.java
@@ -94,7 +94,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p " +
            "LEFT JOIN FETCH p.author " +
            "LEFT JOIN FETCH p.location " +
-           "WHERE p.id = :id")
+           "WHERE p.id = :id AND p.status = 'ACTIVE'")
     Optional<Post> findByIdWithRelations(@Param("id") Long id);
 
 

--- a/src/main/java/com/mypresentpast/backend/repository/ReportRepository.java
+++ b/src/main/java/com/mypresentpast/backend/repository/ReportRepository.java
@@ -2,6 +2,8 @@ package com.mypresentpast.backend.repository;
 
 import com.mypresentpast.backend.enums.ReportStatus;
 import com.mypresentpast.backend.model.Report;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +17,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
                                                     @Param("reporterId") Long reporterId,
                                                     @Param("statuses") Collection<ReportStatus> statuses);
 
+    Page<Report> findByStatus(ReportStatus status, Pageable pageable);
 }

--- a/src/main/java/com/mypresentpast/backend/service/ReportService.java
+++ b/src/main/java/com/mypresentpast/backend/service/ReportService.java
@@ -41,4 +41,26 @@ public interface ReportService {
      * @return Detalle del reporte.
      */
     ReportDetailResponse getReportDetail(Long reportId);
+
+    /**
+     * Acepta un reporte de publicación, cambiando su estado, eliminando la publicación y registrando el administrador que lo acepta.
+     *
+     * @param reportId ID del reporte a aceptar.
+     * @param adminId ID del administrador que realiza la acción.
+     * @return Respuesta indicando el resultado de la operación.
+     * @throws com.mypresentpast.backend.exception.ResourceNotFoundException si el reporte o el administrador no existen.
+     * @throws com.mypresentpast.backend.exception.BadRequestException si el reporte no está en estado válido para ser aceptado.
+     */
+    ApiResponse acceptReport(Long reportId, Long adminId);
+
+    /**
+     * Rechaza un reporte de publicación, cambiando su estado, manteniendo la publicación y registrando el administrador que lo rechaza.
+     *
+     * @param reportId ID del reporte a rechazar.
+     * @param adminId ID del administrador que realiza la acción.
+     * @return Respuesta indicando el resultado de la operación.
+     * @throws com.mypresentpast.backend.exception.ResourceNotFoundException si el reporte o el administrador no existen.
+     * @throws com.mypresentpast.backend.exception.BadRequestException si el reporte no está en estado válido para ser rechazado.
+     */
+    ApiResponse rejectReport(Long reportId, Long adminId);
 }

--- a/src/main/java/com/mypresentpast/backend/service/ReportService.java
+++ b/src/main/java/com/mypresentpast/backend/service/ReportService.java
@@ -1,7 +1,11 @@
 package com.mypresentpast.backend.service;
 
 import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.dto.response.ReportDetailResponse;
+import com.mypresentpast.backend.dto.response.ReportListingResponse;
+import com.mypresentpast.backend.enums.ReportStatus;
 import com.mypresentpast.backend.enums.ReportType;
+import org.springframework.data.domain.Pageable;
 
 public interface ReportService {
     /**
@@ -20,4 +24,21 @@ public interface ReportService {
      */
     ApiResponse createReport(Long postId, String reason, ReportType type);
 
+    /**
+     * Obtiene el listado paginado de reportes de publicaciones.
+     * Permite filtrar por estado si se proporciona el parámetro.
+     *
+     * @param pageable Parámetros de paginación y ordenamiento.
+     * @param status Estado del reporte (opcional).
+     * @return Listado paginado de reportes.
+     */
+    ReportListingResponse getReportListing(Pageable pageable, ReportStatus status);
+
+    /**
+     * Obtiene el detalle de un reporte específico por su ID.
+     *
+     * @param reportId ID del reporte.
+     * @return Detalle del reporte.
+     */
+    ReportDetailResponse getReportDetail(Long reportId);
 }

--- a/src/main/java/com/mypresentpast/backend/service/impl/PostVerificationServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/PostVerificationServiceImpl.java
@@ -49,12 +49,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         // Buscar el post con relaciones cargadas
         Post post = postRepository.findByIdWithRelations(postId)
             .orElseThrow(() -> new ResourceNotFoundException("Post no encontrado"));
-        
-        // Validar que el post esté activo
-        if (post.getStatus() != PostStatus.ACTIVE) {
-            throw new BadRequestException("Solo se pueden verificar posts activos");
-        }
-        
+
         // Validar que no sea su propio post (posts de institución ya están auto-verificados)
         if (post.getAuthor().getId().equals(currentUser.getId())) {
             throw new BadRequestException("No puedes verificar tus propios posts, ya están auto-verificados");

--- a/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
@@ -1,6 +1,6 @@
 package com.mypresentpast.backend.service.impl;
 
-import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.dto.response.*;
 import com.mypresentpast.backend.enums.ReportStatus;
 import com.mypresentpast.backend.enums.ReportType;
 import com.mypresentpast.backend.exception.BadRequestException;
@@ -15,10 +15,13 @@ import com.mypresentpast.backend.service.ReportService;
 import com.mypresentpast.backend.utils.MessageBundle;
 import com.mypresentpast.backend.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.EnumSet;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -47,8 +50,8 @@ public class ReportServiceImpl implements ReportService {
             throw new BadRequestException(String.format(MessageBundle.REPORT_SELF_POST_NOT_ALLOWED, reporterId, postId));
         }
 
-        // Validación de unicidad de negocio (Restricción de duplicidad)
-        if (reportRepository.existsActiveReportByPostIdAndReporterId(postId, reporterId, EnumSet.of(ReportStatus.PENDING, ReportStatus.IN_PROGRESS))) {
+        // Si ya existe un reporte activo (PENDING o ACCEPTED) por parte del mismo usuario para la misma publicación, lanzar excepción
+        if (reportRepository.existsActiveReportByPostIdAndReporterId(postId, reporterId, EnumSet.of(ReportStatus.PENDING, ReportStatus.ACCEPTED))) {
             throw new BadRequestException(String.format(MessageBundle.REPORT_ALREADY_EXISTS_WITH_IDS, reporterId, postId));
         }
         // Construcción del Reporte
@@ -68,4 +71,65 @@ public class ReportServiceImpl implements ReportService {
                 .build();
 
     }
+
+    @Override
+    public ReportListingResponse getReportListing(Pageable pageable, ReportStatus status) {
+        Page<Report> page;
+        // Si se proporciona un estado, filtrar por ese estado
+        if (status != null) {
+            page = reportRepository.findByStatus(status, pageable);
+        } else {
+            page = reportRepository.findAll(pageable);
+        }
+        // Mapear entidades a DTOs
+        List<ReportDetailResponse> dtos = page.getContent().stream()
+                .map(this::mapToReportDetailResponse)
+                .toList();
+        // Construir la respuesta de paginación
+        ReportListingResponse response = new ReportListingResponse();
+        response.setReports(dtos);
+        response.setPage(page.getNumber());
+        response.setSize(page.getSize());
+        response.setTotalElements(page.getTotalElements());
+        response.setTotalPages(page.getTotalPages());
+
+        return response;
+    }
+
+    @Override
+    public ReportDetailResponse getReportDetail(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.REPORT_NOT_FOUND_WITH_ID, reportId)));
+        return mapToDetailResponse(report);
+    }
+
+    // Métodos de mapeo
+    private ReportDetailResponse mapToReportDetailResponse(Report report) {
+        ReportDetailResponse dto = new ReportDetailResponse();
+        dto.setId(report.getId());
+        dto.setType(report.getType());
+        dto.setStatus(report.getStatus());
+        dto.setReason(report.getReason());
+        dto.setCreatedAt(report.getCreatedAt());
+        dto.setPostId(report.getPost().getId());
+        dto.setReporterId(report.getReporter().getId());
+        dto.setPostName(report.getPost().getTitle());
+        return dto;
+    }
+
+    private ReportDetailResponse mapToDetailResponse(Report report) {
+        ReportDetailResponse dto = new ReportDetailResponse();
+        dto.setId(report.getId());
+        dto.setType(report.getType());
+        dto.setStatus(report.getStatus());
+        dto.setReason(report.getReason());
+        dto.setCreatedAt(report.getCreatedAt());
+        dto.setPostId(report.getPost().getId());
+        dto.setPostName(report.getPost().getTitle());
+        dto.setReporterId(report.getReporter().getId());
+        dto.setReporterNickname(report.getReporter().getProfileUsername());
+        dto.setPostAuthorNickname(report.getPost().getAuthor().getProfileUsername());
+        return dto;
+    }
+
 }

--- a/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ReportServiceImpl.java
@@ -11,6 +11,7 @@ import com.mypresentpast.backend.model.User;
 import com.mypresentpast.backend.repository.PostRepository;
 import com.mypresentpast.backend.repository.ReportRepository;
 import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.service.PostService;
 import com.mypresentpast.backend.service.ReportService;
 import com.mypresentpast.backend.utils.MessageBundle;
 import com.mypresentpast.backend.utils.SecurityUtils;
@@ -20,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -28,6 +30,7 @@ import java.util.List;
 public class ReportServiceImpl implements ReportService {
 
     private final PostRepository postRepository;
+    private final PostService postService;
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
 
@@ -132,4 +135,56 @@ public class ReportServiceImpl implements ReportService {
         return dto;
     }
 
+    @Override
+    @Transactional
+    public ApiResponse acceptReport(Long reportId, Long adminId) {
+        // Obtener el reporte
+        Report report = reportRepository.findById(reportId).orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.REPORT_NOT_FOUND_WITH_ID, reportId)));
+
+        // Verificar que el reporte esté en estado PENDING
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new BadRequestException(String.format(MessageBundle.REPORT_ALREADY_PROCESSED, reportId));
+        }
+        report.setStatus(ReportStatus.ACCEPTED);
+        report.setDecisionAt(LocalDateTime.now());
+
+        // Obtener el administrador que toma la decisión
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                    String.format(MessageBundle.ADMIN_NOT_FOUND_WITH_ID, adminId)));
+
+        report.setDecidedBy(admin);
+
+        // Guardar los cambios en el reporte y eliminar la publicación (eliminación lógica)
+        reportRepository.save(report);
+        postService.deletePost(report.getPost().getId());
+
+        String msg = String.format(MessageBundle.REPORT_ACCEPTED_AND_POST_DELETED, report.getId(), admin.getId(), report.getPost().getId());
+
+        return ApiResponse.builder().message(msg).build();
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse rejectReport(Long reportId, Long adminId) {
+        // Obtener el reporte
+        Report report = reportRepository.findById(reportId).orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.REPORT_NOT_FOUND_WITH_ID, reportId)));
+
+        // Verificar que el reporte esté en estado PENDING
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new BadRequestException(String.format(MessageBundle.REPORT_ALREADY_PROCESSED, reportId));
+        }
+        report.setStatus(ReportStatus.REJECTED);
+        report.setDecisionAt(LocalDateTime.now());
+
+        // Obtener el administrador que toma la decisión
+        User admin = userRepository.findById(adminId).orElseThrow(() -> new ResourceNotFoundException(String.format(MessageBundle.ADMIN_NOT_FOUND_WITH_ID, adminId)));
+        report.setDecidedBy(admin);
+
+        // Guardar los cambios en el reporte
+        reportRepository.save(report);
+
+        String msg = String.format(MessageBundle.REPORT_REJECTED_AND_ARCHIVED, report.getId(), admin.getId(), report.getPost().getId());
+        return ApiResponse.builder().message(msg).build();
+    }
 }

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -35,6 +35,7 @@ public class MessageBundle {
     // Reportes
     public static final String REPORT_ALREADY_EXISTS_WITH_IDS = "El usuario con ID [%s] ya reportó la publicación con ID [%s].";
     public static final String REPORT_SELF_POST_NOT_ALLOWED = "El usuario con ID [%s] intentó reportar su propia publicación con ID [%s].";
+    public static final String REPORT_NOT_FOUND_WITH_ID = "Reporte con id [%s] no encontrado";
 
     // Errores generales
     public static final String POST_NOT_FOUND_WITH_ID = "Publicación no encontrado con id [%s] - id usuario [%s]";

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -36,6 +36,11 @@ public class MessageBundle {
     public static final String REPORT_ALREADY_EXISTS_WITH_IDS = "El usuario con ID [%s] ya reportó la publicación con ID [%s].";
     public static final String REPORT_SELF_POST_NOT_ALLOWED = "El usuario con ID [%s] intentó reportar su propia publicación con ID [%s].";
     public static final String REPORT_NOT_FOUND_WITH_ID = "Reporte con id [%s] no encontrado";
+    public static final String REPORT_ALREADY_PROCESSED = "El reporte [%s] ya fue procesado.";
+    public static final String ADMIN_NOT_FOUND_WITH_ID = "Admin [%s] no encontrado.";
+    public static final String REPORT_ACCEPTED_AND_POST_DELETED = "Reporte [%s] aceptado por admin [%s]. Publicación [%s] eliminada.";
+    public static final String REPORT_REJECTED_AND_ARCHIVED = "Reporte [%s] rechazado por admin [%s]. Publicación [%s] mantenida.";
+
 
     // Errores generales
     public static final String POST_NOT_FOUND_WITH_ID = "Publicación no encontrado con id [%s] - id usuario [%s]";

--- a/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
@@ -1,13 +1,18 @@
 package com.mypresentpast.backend.service.impl;
 
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ReportDetailResponse;
 import com.mypresentpast.backend.dto.response.ReportListingResponse;
 import com.mypresentpast.backend.enums.ReportStatus;
 import com.mypresentpast.backend.enums.ReportType;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
 import com.mypresentpast.backend.model.Post;
 import com.mypresentpast.backend.model.Report;
 import com.mypresentpast.backend.model.User;
 import com.mypresentpast.backend.repository.ReportRepository;
+import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.service.PostService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -20,12 +25,16 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ReportServiceImplTest {
 
     @Mock
     private ReportRepository reportRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PostService postService;
 
     @InjectMocks
     private ReportServiceImpl reportService;
@@ -33,6 +42,7 @@ class ReportServiceImplTest {
     private Report testReport;
     private Post testPost;
     private User testUser;
+    private User adminUser;
 
     @BeforeEach
     void setUp() {
@@ -43,6 +53,9 @@ class ReportServiceImplTest {
         testUser.setProfileUsername("reporter");
         testUser.setName("Juan");
         testUser.setLastName("Pérez");
+
+        adminUser = new User();
+        adminUser.setId(99L);
 
         testPost = new Post();
         testPost.setId(2L);
@@ -102,4 +115,71 @@ class ReportServiceImplTest {
         assertThrows(RuntimeException.class, () -> reportService.getReportDetail(99L));
     }
 
+    @Test
+    void acceptReport_Success() {
+        // Simular el comportamiento del repositorio y servicio
+        when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
+        when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
+        when(reportRepository.save(any(Report.class))).thenReturn(testReport);
+
+        ApiResponse response = reportService.acceptReport(10L, 99L);
+
+        assertNotNull(response);
+        // Verificar que el mensaje contenga la palabra "aceptado"
+        assertTrue(response.getMessage().contains("aceptado"));
+        // Verificar que el estado del reporte sea ACCEPTED
+        assertEquals(ReportStatus.ACCEPTED, testReport.getStatus());
+        // Verificar que se haya llamado a deletePost del servicio PostService
+        verify(postService).deletePost(anyLong());
+    }
+
+    @Test
+    void acceptReport_ReportNotFound_ThrowsException() {
+        // Simular que el reporte no existe
+        when(reportRepository.findById(10L)).thenReturn(Optional.empty());
+        // Asegurarse de que se lance la excepción ResourceNotFoundException
+        assertThrows(ResourceNotFoundException.class, () -> reportService.acceptReport(10L, 99L));
+    }
+
+    @Test
+    void acceptReport_InvalidStatus_ThrowsException() {
+        // Cambiar el estado del reporte a REJECTED para simular un estado inválido
+        testReport.setStatus(ReportStatus.REJECTED);
+        when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
+        // Asegurarse de que se lance la excepción BadRequestException
+        assertThrows(BadRequestException.class, () -> reportService.acceptReport(10L, 99L));
+    }
+
+    @Test
+    void rejectReport_Success() {
+        // Simular el comportamiento del repositorio y servicio
+        when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
+        when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
+        when(reportRepository.save(any(Report.class))).thenReturn(testReport);
+
+        ApiResponse response = reportService.rejectReport(10L, 99L);
+
+        assertNotNull(response);
+        // Verificar que el mensaje contenga la palabra "rechazado"
+        assertTrue(response.getMessage().contains("rechazado"));
+        // Verificar que el estado del reporte sea REJECTED
+        assertEquals(ReportStatus.REJECTED, testReport.getStatus());
+    }
+
+    @Test
+    void rejectReport_ReportNotFound_ThrowsException() {
+        // Simular que el reporte no existe
+        when(reportRepository.findById(10L)).thenReturn(Optional.empty());
+        // asegurarse de que se lance la excepción ResourceNotFoundException
+        assertThrows(ResourceNotFoundException.class, () -> reportService.rejectReport(10L, 99L));
+    }
+
+    @Test
+    void rejectReport_InvalidStatus_ThrowsException() {
+        // Cambiar el estado del reporte a ACCEPTED para simular un estado inválido
+        testReport.setStatus(ReportStatus.ACCEPTED);
+        when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
+        // asegurarse de que se lance la excepción BadRequestException
+        assertThrows(BadRequestException.class, () -> reportService.rejectReport(10L, 99L));
+    }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,105 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.response.ReportDetailResponse;
+import com.mypresentpast.backend.dto.response.ReportListingResponse;
+import com.mypresentpast.backend.enums.ReportStatus;
+import com.mypresentpast.backend.enums.ReportType;
+import com.mypresentpast.backend.model.Post;
+import com.mypresentpast.backend.model.Report;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class ReportServiceImplTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @InjectMocks
+    private ReportServiceImpl reportService;
+
+    private Report testReport;
+    private Post testPost;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setProfileUsername("reporter");
+        testUser.setName("Juan");
+        testUser.setLastName("Pérez");
+
+        testPost = new Post();
+        testPost.setId(2L);
+        testPost.setTitle("Título del post");
+        testPost.setAuthor(testUser);
+
+        testReport = new Report();
+        testReport.setId(10L);
+        testReport.setType(ReportType.SPAM);
+        testReport.setStatus(ReportStatus.PENDING);
+        testReport.setReason("Motivo de prueba");
+        testReport.setCreatedAt(LocalDateTime.now());
+        testReport.setPost(testPost);
+        testReport.setReporter(testUser);
+
+    }
+
+    @Test
+    void getReportListing_ReturnsPagedReports() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Page<Report> page = new PageImpl<>(List.of(testReport), pageable, 1);
+
+        when(reportRepository.findAll(pageable)).thenReturn(page);
+
+        ReportListingResponse response = reportService.getReportListing(pageable, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getReports().size());
+        assertEquals(testReport.getId(), response.getReports().get(0).getId());
+        assertEquals(testReport.getType(), response.getReports().get(0).getType());
+        assertEquals(testReport.getStatus(), response.getReports().get(0).getStatus());
+        assertEquals(testReport.getPost().getId(), response.getReports().get(0).getPostId());
+        assertEquals(testReport.getReporter().getId(), response.getReports().get(0).getReporterId());
+    }
+
+    @Test
+    void getReportDetail_ReturnsReportDetail() {
+        when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
+
+        ReportDetailResponse dto = reportService.getReportDetail(10L);
+
+        assertNotNull(dto);
+        assertEquals(testReport.getId(), dto.getId());
+        assertEquals(testReport.getType(), dto.getType());
+        assertEquals(testReport.getStatus(), dto.getStatus());
+        assertEquals(testReport.getReason(), dto.getReason());
+        assertEquals(testReport.getPost().getId(), dto.getPostId());
+        assertEquals(testReport.getPost().getTitle(), dto.getPostName());
+        assertEquals(testReport.getReporter().getId(), dto.getReporterId());
+        assertEquals(testReport.getReporter().getProfileUsername(), dto.getReporterNickname());
+    }
+
+    @Test
+    void getReportDetail_ReportNotFound_ThrowsException() {
+        when(reportRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> reportService.getReportDetail(99L));
+    }
+
+}


### PR DESCRIPTION
Implementación de aceptación y rechazo de reportes por administradores

- Se agregaron los métodos acceptReport y rejectReport en el controlador y servicio, permitiendo a los administradores aceptar o rechazar reportes de publicaciones.
- Se documentaron todos los métodos nuevos y existentes en las interfaces correspondientes.
- Se actualizó el modelo Report para registrar la fecha y el usuario administrador que toma la decisión.
- Se agregaron mensajes descriptivos en MessageBundle para los resultados de las acciones.
- Se modificó el repositorio de posts para asegurar que solo se obtengan publicaciones activas.
- Se agregaron y mejoraron las pruebas unitarias para cubrir los casos de éxito y error en la aceptación y rechazo de reportes, alcanzando más del 80% de cobertura en esos métodos.