### PR TITLE
SCRUM-210 agregar tests unitarios para aumentar cobertura de código

### DIFF
--- a/src/test/java/com/mypresentpast/backend/service/ai/GroqProviderTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/ai/GroqProviderTest.java
@@ -1,0 +1,190 @@
+package com.mypresentpast.backend.service.ai;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+// RestTemplate se crea en el constructor con new RestTemplate(), por lo que se inyecta
+// el mock via reflexión. Los campos @Value también se inyectan por reflexión en setUp().
+@ExtendWith(MockitoExtension.class)
+class GroqProviderTest {
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    private GroqProvider groqProvider;
+
+    private static final String VALID_API_KEY = "gsk_valid_test_key_not_demo";
+    private static final String API_URL = "https://api.groq.com/openai/v1/chat/completions";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        groqProvider = new GroqProvider();
+        setField("apiKey", VALID_API_KEY);
+        setField("apiUrl", API_URL);
+        setField("model", "llama-3.1-8b-instant");
+        setField("maxTokens", 1000);
+        setField("temperature", 0.3);
+
+        Field restTemplateField = GroqProvider.class.getDeclaredField("restTemplate");
+        restTemplateField.setAccessible(true);
+        restTemplateField.set(groqProvider, mockRestTemplate);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = GroqProvider.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(groqProvider, value);
+    }
+
+    // ── correctContent ─────────────────────────────────────────────────────
+
+    // Una clave inválida (null, vacía o demo) debe lanzar IllegalStateException sin llamar a la API.
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "gsk_demo"})
+    void correctContent_InvalidApiKey_ThrowsIllegalStateException(String invalidKey) throws Exception {
+        setField("apiKey", invalidKey);
+
+        assertThrows(IllegalStateException.class, () -> groqProvider.correctContent("texto"));
+
+        verifyNoInteractions(mockRestTemplate);
+    }
+
+    // Con clave válida y respuesta exitosa, retorna el contenido corregido sin espacios extra.
+    @Test
+    void correctContent_ValidApiKey_ReturnsCorrectContent() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(responseWithContent("  texto corregido  "));
+
+        String result = groqProvider.correctContent("texto a correguir");
+
+        assertEquals("texto corregido", result);
+        verify(mockRestTemplate).exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    // Cuando la API lanza una excepción de red, debe envolverse en RuntimeException con mensaje descriptivo.
+    @Test
+    void correctContent_RestTemplateThrowsException_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Timeout de red"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> groqProvider.correctContent("texto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de Groq"));
+    }
+
+    // ── generatePostContent ────────────────────────────────────────────────
+
+    // La clave "gsk_demo" debe lanzar IllegalStateException sin generar contenido.
+    @Test
+    void generatePostContent_DemoApiKey_ThrowsIllegalStateException() throws Exception {
+        setField("apiKey", "gsk_demo");
+
+        assertThrows(IllegalStateException.class,
+                () -> groqProvider.generatePostContent("2024-01-15", "Buenos Aires, Argentina", "contexto"));
+
+        verifyNoInteractions(mockRestTemplate);
+    }
+
+    // Con parámetros válidos y respuesta exitosa, retorna el contenido generado sin espacios extra.
+    @Test
+    void generatePostContent_ValidRequest_ReturnsGeneratedContent() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(responseWithContent("  {\"title\":\"Título\",\"content\":\"Contenido\"}  "));
+
+        String result = groqProvider.generatePostContent("2024-01-15", "Buenos Aires, Argentina", "fui al estadio");
+
+        assertEquals("{\"title\":\"Título\",\"content\":\"Contenido\"}", result);
+        verify(mockRestTemplate).exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    // Un cuerpo de respuesta nulo debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_NullResponseBody_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> groqProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de Groq"));
+    }
+
+    // Una lista de choices vacía debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_EmptyChoices_ThrowsRuntimeException() {
+        Map<String, Object> body = Map.of("choices", List.of());
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> groqProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de Groq"));
+    }
+
+    // Un message nulo en el primer choice debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_NullMessage_ThrowsRuntimeException() {
+        Map<String, Object> choiceWithNullMessage = new HashMap<>();
+        choiceWithNullMessage.put("message", null);
+        Map<String, Object> body = Map.of("choices", List.of(choiceWithNullMessage));
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> groqProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de Groq"));
+    }
+
+    // Cuando la API lanza excepción al generar, debe envolverse en RuntimeException.
+    @Test
+    void generatePostContent_RestTemplateThrowsException_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> groqProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de Groq"));
+    }
+
+    // ── getProviderName ────────────────────────────────────────────────────
+
+    // El nombre del proveedor debe identificar a Groq como gratuito.
+    @Test
+    void getProviderName_ReturnsGroqProviderName() {
+        assertEquals("Groq (Gratuito)", groqProvider.getProviderName());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<Map> responseWithContent(String content) {
+        Map<String, Object> message = Map.of("content", content);
+        Map<String, Object> choice = Map.of("message", message);
+        Map<String, Object> body = Map.of("choices", List.of(choice));
+        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/ai/OpenAIProviderTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/ai/OpenAIProviderTest.java
@@ -1,0 +1,195 @@
+package com.mypresentpast.backend.service.ai;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+// RestTemplate se crea en el constructor con new RestTemplate(), por lo que se inyecta
+// el mock via reflexión. Los campos @Value también se inyectan por reflexión en setUp().
+@ExtendWith(MockitoExtension.class)
+class OpenAIProviderTest {
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    private OpenAIProvider openAIProvider;
+
+    private static final String VALID_API_KEY = "sk-valid-test-api-key";
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        openAIProvider = new OpenAIProvider();
+        setField("apiKey", VALID_API_KEY);
+        setField("apiUrl", API_URL);
+        setField("model", "gpt-3.5-turbo");
+        setField("maxTokens", 1000);
+        setField("temperature", 0.3);
+
+        Field restTemplateField = OpenAIProvider.class.getDeclaredField("restTemplate");
+        restTemplateField.setAccessible(true);
+        restTemplateField.set(openAIProvider, mockRestTemplate);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = OpenAIProvider.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(openAIProvider, value);
+    }
+
+    // ── correctContent ─────────────────────────────────────────────────────
+
+    // Una clave vacía debe lanzar IllegalStateException sin llamar a la API.
+    @Test
+    void correctContent_EmptyApiKey_ThrowsIllegalStateException() throws Exception {
+        setField("apiKey", "");
+
+        assertThrows(IllegalStateException.class, () -> openAIProvider.correctContent("texto"));
+
+        verifyNoInteractions(mockRestTemplate);
+    }
+
+    // Una clave null debe lanzar IllegalStateException sin llamar a la API.
+    @Test
+    void correctContent_NullApiKey_ThrowsIllegalStateException() throws Exception {
+        setField("apiKey", null);
+
+        assertThrows(IllegalStateException.class, () -> openAIProvider.correctContent("texto"));
+
+        verifyNoInteractions(mockRestTemplate);
+    }
+
+    // Con clave válida y respuesta exitosa, retorna el contenido corregido sin espacios extra.
+    @Test
+    void correctContent_ValidApiKey_ReturnsCorrectContent() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(responseWithContent("  texto corregido  "));
+
+        String result = openAIProvider.correctContent("texto a correguir");
+
+        assertEquals("texto corregido", result);
+        verify(mockRestTemplate).exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    // Cuando la API lanza una excepción de red, debe envolverse en RuntimeException con mensaje descriptivo.
+    @Test
+    void correctContent_RestTemplateThrowsException_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Timeout de red"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> openAIProvider.correctContent("texto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de OpenAI"));
+    }
+
+    // ── generatePostContent ────────────────────────────────────────────────
+
+    // Una clave vacía debe lanzar IllegalStateException sin generar contenido.
+    @Test
+    void generatePostContent_EmptyApiKey_ThrowsIllegalStateException() throws Exception {
+        setField("apiKey", "");
+
+        assertThrows(IllegalStateException.class,
+                () -> openAIProvider.generatePostContent("2024-01-15", "Buenos Aires, Argentina", "contexto"));
+
+        verifyNoInteractions(mockRestTemplate);
+    }
+
+    // Con parámetros válidos y respuesta exitosa, retorna el contenido generado sin espacios extra.
+    @Test
+    void generatePostContent_ValidRequest_ReturnsGeneratedContent() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(responseWithContent("  {\"title\":\"Título\",\"content\":\"Contenido\"}  "));
+
+        String result = openAIProvider.generatePostContent("2024-01-15", "Buenos Aires, Argentina", "fui al estadio");
+
+        assertEquals("{\"title\":\"Título\",\"content\":\"Contenido\"}", result);
+        verify(mockRestTemplate).exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    // Un cuerpo de respuesta nulo debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_NullResponseBody_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> openAIProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de OpenAI"));
+    }
+
+    // Una lista de choices vacía debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_EmptyChoices_ThrowsRuntimeException() {
+        Map<String, Object> body = Map.of("choices", List.of());
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> openAIProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de OpenAI"));
+    }
+
+    // Un message nulo en el primer choice debe lanzar RuntimeException envuelta.
+    @Test
+    void generatePostContent_NullMessage_ThrowsRuntimeException() {
+        Map<String, Object> choiceWithNullMessage = new HashMap<>();
+        choiceWithNullMessage.put("message", null);
+        Map<String, Object> body = Map.of("choices", List.of(choiceWithNullMessage));
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> openAIProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de OpenAI"));
+    }
+
+    // Cuando la API lanza excepción al generar, debe envolverse en RuntimeException.
+    @Test
+    void generatePostContent_RestTemplateThrowsException_ThrowsRuntimeException() {
+        when(mockRestTemplate.exchange(eq(API_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> openAIProvider.generatePostContent("2024-01-15", "Buenos Aires", "contexto"));
+
+        assertTrue(ex.getMessage().contains("Error en API de OpenAI"));
+    }
+
+    // ── getProviderName ────────────────────────────────────────────────────
+
+    // El nombre del proveedor debe identificar correctamente a OpenAI.
+    @Test
+    void getProviderName_ReturnsOpenAIProviderName() {
+        assertEquals("OpenAI", openAIProvider.getProviderName());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<Map> responseWithContent(String content) {
+        Map<String, Object> message = Map.of("content", content);
+        Map<String, Object> choice = Map.of("message", message);
+        Map<String, Object> body = Map.of("choices", List.of(choice));
+        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/AdminServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/AdminServiceImplTest.java
@@ -1,0 +1,373 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.response.AdminInstitutionRequestResponse;
+import com.mypresentpast.backend.enums.InstitutionType;
+import com.mypresentpast.backend.enums.RequestStatus;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.exception.UnauthorizedException;
+import com.mypresentpast.backend.model.InstitutionRequest;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
+import com.mypresentpast.backend.repository.InstitutionRequestRepository;
+import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.utils.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceImplTest {
+
+    // ── Mocks ──────────────────────────────────────────────────────────────
+    @Mock
+    private InstitutionRequestRepository institutionRequestRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminServiceImpl adminService;
+
+    // ── Datos de test reutilizables ────────────────────────────────────────
+    private User adminUser;
+    private User requestUser;
+    private InstitutionRequest testRequest;
+
+    // ── Setup ──────────────────────────────────────────────────────────────
+    @BeforeEach
+    void setUp() {
+        adminUser = new User();
+        adminUser.setId(99L);
+        adminUser.setRole(UserRole.ADMIN);
+        adminUser.setName("Admin");
+
+        requestUser = new User();
+        requestUser.setId(1L);
+        requestUser.setRole(UserRole.NORMAL);
+        requestUser.setName("John");
+        requestUser.setAvatar("avatar.jpg");
+
+        testRequest = InstitutionRequest.builder()
+                .id(10L)
+                .user(requestUser)
+                .institutionName("Museo Nacional")
+                .legalAddress("Av. Siempre Viva 742, Springfield")
+                .documentUrl("https://cloudinary.com/doc.pdf")
+                .officialPhone("+5491112345678")
+                .type(InstitutionType.MUSEUM)
+                .status(RequestStatus.PENDING)
+                .createdAt(LocalDateTime.of(2026, 1, 15, 10, 0))
+                .build();
+    }
+
+    // ── getAllRequests ─────────────────────────────────────────────────────
+
+    // Verifica que con filtro de estado se llama findByStatusWithUserInfo y se mapean los resultados.
+    @Test
+    void getAllRequests_WithStatusFilter_ReturnsFilteredMappedList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByStatusWithUserInfo(RequestStatus.PENDING))
+                    .thenReturn(List.of(testRequest));
+
+            List<AdminInstitutionRequestResponse> result = adminService.getAllRequests(RequestStatus.PENDING);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals(10L, result.get(0).getId());
+            assertEquals("Museo Nacional", result.get(0).getInstitutionName());
+            assertEquals(RequestStatus.PENDING, result.get(0).getStatus());
+            verify(institutionRequestRepository).findByStatusWithUserInfo(RequestStatus.PENDING);
+            verify(institutionRequestRepository, never()).findAllWithUserInfo();
+        }
+    }
+
+    // Verifica que sin filtro de estado se llama findAllWithUserInfo y se mapean todos los resultados.
+    @Test
+    void getAllRequests_WithoutStatusFilter_ReturnsAllMappedRequests() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findAllWithUserInfo()).thenReturn(List.of(testRequest));
+
+            List<AdminInstitutionRequestResponse> result = adminService.getAllRequests(null);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            verify(institutionRequestRepository).findAllWithUserInfo();
+            verify(institutionRequestRepository, never()).findByStatusWithUserInfo(any());
+        }
+    }
+
+    // Verifica que si no hay solicitudes se retorna una lista vacía.
+    @Test
+    void getAllRequests_NoRequests_ReturnsEmptyList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findAllWithUserInfo()).thenReturn(List.of());
+
+            List<AdminInstitutionRequestResponse> result = adminService.getAllRequests(null);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // ── getRequestDetail ───────────────────────────────────────────────────
+
+    // Verifica que buscar el detalle de una solicitud existente retorna la respuesta correctamente mapeada.
+    @Test
+    void getRequestDetail_ExistingId_ReturnsMappedResponse() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+
+            AdminInstitutionRequestResponse result = adminService.getRequestDetail(10L);
+
+            assertNotNull(result);
+            assertEquals(10L, result.getId());
+            assertEquals("Museo Nacional", result.getInstitutionName());
+            assertEquals(RequestStatus.PENDING, result.getStatus());
+            assertNotNull(result.getUser());
+            assertEquals(1L, result.getUser().getId());
+        }
+    }
+
+    // Verifica que buscar el detalle de una solicitud inexistente lanza ResourceNotFoundException.
+    @Test
+    void getRequestDetail_NotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> adminService.getRequestDetail(99L));
+        }
+    }
+
+    // ── approveRequest ─────────────────────────────────────────────────────
+
+    // Verifica que aprobar una solicitud PENDING cambia su estado a APPROVED y el rol del usuario a INSTITUTION.
+    @Test
+    void approveRequest_ValidPendingRequest_ApprovesAndChangesUserRoleToInstitution() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+            when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
+
+            adminService.approveRequest(10L);
+
+            assertEquals(RequestStatus.APPROVED, testRequest.getStatus());
+            assertEquals(adminUser, testRequest.getReviewedBy());
+            assertNotNull(testRequest.getReviewedAt());
+            assertNull(testRequest.getRejectionReason());
+            assertEquals(UserRole.INSTITUTION, requestUser.getRole());
+            verify(institutionRequestRepository).save(testRequest);
+            verify(userRepository).save(requestUser);
+        }
+    }
+
+    // Verifica que aprobar una solicitud inexistente lanza ResourceNotFoundException.
+    @Test
+    void approveRequest_RequestNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> adminService.approveRequest(99L));
+
+            verify(institutionRequestRepository, never()).save(any());
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que aprobar una solicitud que no está en estado PENDING lanza BadRequestException.
+    @Test
+    void approveRequest_RequestNotPending_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            testRequest.setStatus(RequestStatus.APPROVED);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+
+            assertThrows(BadRequestException.class, () -> adminService.approveRequest(10L));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que aprobar una solicitud cuyo usuario ya es INSTITUTION lanza BadRequestException.
+    @Test
+    void approveRequest_UserAlreadyInstitution_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            requestUser.setRole(UserRole.INSTITUTION);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+
+            assertThrows(BadRequestException.class, () -> adminService.approveRequest(10L));
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que no se puede convertir a un ADMIN en institución.
+    @Test
+    void approveRequest_UserIsAdmin_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            requestUser.setRole(UserRole.ADMIN);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+
+            assertThrows(BadRequestException.class, () -> adminService.approveRequest(10L));
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que si el admin actual no existe en la DB se lanza UnauthorizedException.
+    @Test
+    void approveRequest_AdminNotFound_ThrowsUnauthorizedException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(UnauthorizedException.class, () -> adminService.approveRequest(10L));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // ── rejectRequest ──────────────────────────────────────────────────────
+
+    // Verifica que rechazar una solicitud PENDING con motivo válido la marca como REJECTED y guarda el motivo.
+    @Test
+    void rejectRequest_ValidPendingRequest_RejectsWithReason() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            String reason = "La documentación presentada no cumple con los requisitos mínimos.";
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+            when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
+
+            adminService.rejectRequest(10L, reason);
+
+            assertEquals(RequestStatus.REJECTED, testRequest.getStatus());
+            assertEquals(reason.trim(), testRequest.getRejectionReason());
+            assertEquals(adminUser, testRequest.getReviewedBy());
+            assertNotNull(testRequest.getReviewedAt());
+            verify(institutionRequestRepository).save(testRequest);
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que rechazar sin motivo (null) lanza BadRequestException.
+    @Test
+    void rejectRequest_NullReason_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+
+            assertThrows(BadRequestException.class, () -> adminService.rejectRequest(10L, null));
+
+            verify(institutionRequestRepository, never()).findByIdWithUserInfo(any());
+        }
+    }
+
+    // Verifica que rechazar con motivo vacío lanza BadRequestException.
+    @Test
+    void rejectRequest_EmptyReason_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+
+            assertThrows(BadRequestException.class, () -> adminService.rejectRequest(10L, "   "));
+
+            verify(institutionRequestRepository, never()).findByIdWithUserInfo(any());
+        }
+    }
+
+    // Verifica que un motivo de menos de 10 caracteres lanza BadRequestException.
+    @Test
+    void rejectRequest_ReasonTooShort_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+
+            assertThrows(BadRequestException.class, () -> adminService.rejectRequest(10L, "Corto"));
+
+            verify(institutionRequestRepository, never()).findByIdWithUserInfo(any());
+        }
+    }
+
+    // Verifica que un motivo de más de 500 caracteres lanza BadRequestException.
+    @Test
+    void rejectRequest_ReasonTooLong_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            String longReason = "x".repeat(501);
+
+            assertThrows(BadRequestException.class, () -> adminService.rejectRequest(10L, longReason));
+
+            verify(institutionRequestRepository, never()).findByIdWithUserInfo(any());
+        }
+    }
+
+    // Verifica que rechazar una solicitud inexistente lanza ResourceNotFoundException.
+    @Test
+    void rejectRequest_RequestNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> adminService.rejectRequest(99L, "Motivo de rechazo válido con longitud correcta."));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que rechazar una solicitud que no está en estado PENDING lanza BadRequestException.
+    @Test
+    void rejectRequest_RequestNotPending_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            testRequest.setStatus(RequestStatus.APPROVED);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+
+            assertThrows(BadRequestException.class,
+                    () -> adminService.rejectRequest(10L, "Motivo de rechazo válido con longitud correcta."));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que si el admin actual no existe en la DB se lanza UnauthorizedException.
+    @Test
+    void rejectRequest_AdminNotFound_ThrowsUnauthorizedException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(institutionRequestRepository.findByIdWithUserInfo(10L))
+                    .thenReturn(Optional.of(testRequest));
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(UnauthorizedException.class,
+                    () -> adminService.rejectRequest(10L, "Motivo de rechazo válido con longitud correcta."));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/CloudinaryServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/CloudinaryServiceImplTest.java
@@ -1,0 +1,293 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.Uploader;
+import com.mypresentpast.backend.exception.CloudinaryException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+// Cloudinary se construye internamente en el constructor con @Value, por lo que se inyecta
+// el mock via reflexión. El stub de uploader() se configura en cada test que lo necesita
+// para respetar strict stubbing sin UnnecessaryStubbingException.
+@ExtendWith(MockitoExtension.class)
+class CloudinaryServiceImplTest {
+
+    @Mock
+    private Cloudinary mockCloudinary;
+    @Mock
+    private Uploader mockUploader;
+
+    private CloudinaryServiceImpl cloudinaryService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Crear instancia con valores dummy (los @Value no se usan en tests)
+        cloudinaryService = new CloudinaryServiceImpl("test-cloud", "test-key", "test-secret");
+
+        // Inyectar el mock de Cloudinary en el campo private final via reflexión
+        Field cloudinaryField = CloudinaryServiceImpl.class.getDeclaredField("cloudinary");
+        cloudinaryField.setAccessible(true);
+        cloudinaryField.set(cloudinaryService, mockCloudinary);
+    }
+
+    // ── upload(MultipartFile) ──────────────────────────────────────────────
+
+    // Verifica que una imagen JPEG válida se convierte, sube a Cloudinary y retorna el resultado.
+    @Test
+    void upload_ValidJpegFile_UploadsToCloudinaryAndReturnsResult() throws Exception {
+        MultipartFile file = validImageMock("image/jpeg");
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.upload(any(Object.class), any(Map.class))).thenReturn(
+                Map.of("url", "https://cloudinary.com/result.jpg", "public_id", "test_id"));
+
+        Map<String, Object> result = cloudinaryService.upload(file);
+
+        assertNotNull(result);
+        assertEquals("https://cloudinary.com/result.jpg", result.get("url"));
+        verify(mockUploader).upload(any(Object.class), any(Map.class));
+    }
+
+    // Verifica que un archivo mayor a 10MB lanza RuntimeException antes de intentar la subida.
+    @Test
+    void upload_FileTooLarge_ThrowsRuntimeException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(11L * 1024 * 1024);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> cloudinaryService.upload(file));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que un tipo de contenido no permitido lanza RuntimeException antes de intentar la subida.
+    @Test
+    void upload_InvalidContentType_ThrowsRuntimeException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getContentType()).thenReturn("application/pdf");
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> cloudinaryService.upload(file));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // ── uploadAvatar ───────────────────────────────────────────────────────
+
+    // Verifica que subir un avatar válido llama a Cloudinary con el publicId correcto y retorna el resultado.
+    @Test
+    void uploadAvatar_ValidFile_ReturnsUploadResult() throws Exception {
+        MultipartFile file = validAvatarFileMock("image/jpeg");
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.upload(any(byte[].class), any(Map.class))).thenReturn(
+                Map.of("secure_url", "https://cloudinary.com/avatar.jpg"));
+
+        Map<String, Object> result = cloudinaryService.uploadAvatar(file, 1L);
+
+        assertNotNull(result);
+        assertEquals("https://cloudinary.com/avatar.jpg", result.get("secure_url"));
+        verify(mockUploader).upload(any(byte[].class), any(Map.class));
+    }
+
+    // Verifica que pasar un archivo nulo lanza CloudinaryException (validateImage detecta null).
+    @Test
+    void uploadAvatar_NullFile_ThrowsCloudinaryException() throws Exception {
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(null, 1L));
+
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que pasar un archivo vacío lanza CloudinaryException.
+    @Test
+    void uploadAvatar_EmptyFile_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(true);
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(file, 1L));
+
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que un avatar mayor a 10MB lanza CloudinaryException.
+    @Test
+    void uploadAvatar_FileTooLarge_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(11L * 1024 * 1024);
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(file, 1L));
+
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que un avatar con tipo de contenido no permitido lanza CloudinaryException.
+    @Test
+    void uploadAvatar_InvalidContentType_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("image/gif"); // gif no está permitido en avatars
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(file, 1L));
+
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // ── delete ─────────────────────────────────────────────────────────────
+
+    // Verifica que eliminar por publicId llama a Cloudinary destroy y retorna el resultado.
+    @Test
+    void delete_ValidPublicId_CallsDestroyAndReturnsResult() throws Exception {
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.destroy(eq("cloudinary_id_123"), any(Map.class))).thenReturn(
+                Map.of("result", "ok"));
+
+        Map<String, Object> result = cloudinaryService.delete("cloudinary_id_123");
+
+        assertNotNull(result);
+        assertEquals("ok", result.get("result"));
+        verify(mockUploader).destroy(eq("cloudinary_id_123"), any(Map.class));
+    }
+
+    // ── upload(MultipartFile, Map) ─────────────────────────────────────────
+
+    // Verifica que subir con opciones personalizadas las pasa directamente a Cloudinary.
+    @Test
+    void uploadWithOptions_ValidFile_UploadsWithCustomOptionsAndReturnsResult() throws Exception {
+        MultipartFile file = validOptionsFileMock();
+        Map<String, Object> customOptions = Map.of("folder", "posts", "resource_type", "image");
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.upload(any(Object.class), eq(customOptions))).thenReturn(
+                Map.of("public_id", "posts/test_id", "url", "https://cloudinary.com/post.jpg"));
+
+        Map<String, Object> result = cloudinaryService.upload(file, customOptions);
+
+        assertNotNull(result);
+        assertEquals("posts/test_id", result.get("public_id"));
+        verify(mockUploader).upload(any(Object.class), eq(customOptions));
+    }
+
+    // Verifica que si Cloudinary falla al subir con opciones se lanza CloudinaryException.
+    @Test
+    void uploadWithOptions_UploaderThrowsException_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = validOptionsFileMock();
+        Map<String, Object> options = Map.of("folder", "test");
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.upload(any(Object.class), any(Map.class))).thenThrow(new IOException("connection error"));
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.upload(file, options));
+    }
+
+    // Verifica que un archivo marcado como vacío falla la validación isValidImageType y lanza RuntimeException.
+    @Test
+    void upload_EmptyFile_ThrowsRuntimeException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.isEmpty()).thenReturn(true);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> cloudinaryService.upload(file));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que un archivo con contentType null falla la validación isValidImageType y lanza RuntimeException.
+    @Test
+    void upload_NullContentType_ThrowsRuntimeException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getContentType()).thenReturn(null);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> cloudinaryService.upload(file));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que si Cloudinary lanza excepción al eliminar, se relanza como RuntimeException.
+    @Test
+    void delete_UploaderThrowsException_ThrowsRuntimeException() throws Exception {
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.destroy(eq("bad_id"), any(Map.class))).thenThrow(new IOException("network error"));
+
+        assertThrows(RuntimeException.class, () -> cloudinaryService.delete("bad_id"));
+    }
+
+    // Verifica que un avatar con contentType null lanza CloudinaryException en validateImage.
+    @Test
+    void uploadAvatar_NullContentType_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn(null);
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(file, 1L));
+
+        verify(mockUploader, never()).upload(any(), any());
+    }
+
+    // Verifica que si Cloudinary lanza excepción al subir el avatar, se relanza como CloudinaryException.
+    @Test
+    void uploadAvatar_UploaderThrowsIOException_ThrowsCloudinaryException() throws Exception {
+        MultipartFile file = validAvatarFileMock("image/jpeg");
+        when(mockCloudinary.uploader()).thenReturn(mockUploader);
+        when(mockUploader.upload(any(byte[].class), any(Map.class))).thenThrow(new IOException("connection error"));
+
+        assertThrows(CloudinaryException.class, () -> cloudinaryService.uploadAvatar(file, 1L));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Mock para upload(MultipartFile): valida tamaño, tipo y llama a convert() internamente.
+     * Necesita: getSize, isEmpty, getContentType, getOriginalFilename, getBytes.
+     */
+    private MultipartFile validImageMock(String contentType) throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getContentType()).thenReturn(contentType);
+        when(file.getOriginalFilename()).thenReturn("test-image.jpg");
+        when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
+        return file;
+    }
+
+    /**
+     * Mock para uploadAvatar: valida tamaño y tipo pero NO llama a convert().
+     * Necesita: isEmpty, getSize, getContentType, getBytes (sin getOriginalFilename).
+     */
+    private MultipartFile validAvatarFileMock(String contentType) throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn(contentType);
+        when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
+        return file;
+    }
+
+    /**
+     * Mock para upload(MultipartFile, Map): no valida tipo/tamaño, solo llama a convert().
+     * Necesita: getOriginalFilename, getBytes (sin getSize/isEmpty/getContentType).
+     */
+    private MultipartFile validOptionsFileMock() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getOriginalFilename()).thenReturn("test-image.jpg");
+        when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
+        return file;
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/CollectionServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/CollectionServiceImplTest.java
@@ -43,6 +43,9 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.mypresentpast.backend.enums.MediaType;
+import com.mypresentpast.backend.model.Location;
+import com.mypresentpast.backend.model.Media;
 
 @ExtendWith(MockitoExtension.class)
 class CollectionServiceImplTest {
@@ -473,12 +476,12 @@ class CollectionServiceImplTest {
         Long postId = 1L;
         List<CollectionPost> collectionPosts = List.of(testCollectionPost);
 
-        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity = 
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
              Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
-            
+
             mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
                          .thenReturn(userId);
-            
+
             when(postRepository.findById(postId)).thenReturn(Optional.of(testPost));
             when(collectionPostRepository.findByPostIdAndCollectionAuthorId(postId, userId))
                 .thenReturn(collectionPosts);
@@ -491,6 +494,484 @@ class CollectionServiceImplTest {
             assertEquals(postId, result.getPostId());
             assertEquals(1, result.getCollectionsContaining().size());
             assertEquals("Test Collection", result.getCollectionsContaining().get(0).getCollectionName());
+        }
+    }
+
+    // Verifica que updateCollection lanza ResourceNotFoundException cuando la colección no pertenece al usuario.
+    @Test
+    void updateCollection_CollectionNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+        UpdateCollectionRequest request = new UpdateCollectionRequest();
+        request.setName("Updated");
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(99L, userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.updateCollection(99L, request));
+        }
+    }
+
+    // Verifica que updateCollection lanza BadRequestException cuando el nuevo nombre ya existe en otra colección.
+    @Test
+    void updateCollection_DuplicateName_ThrowsBadRequestException() {
+        Long userId = 1L;
+        UpdateCollectionRequest request = new UpdateCollectionRequest();
+        request.setName("Other Collection");
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorIdAndIdNot("Other Collection", userId, 1L))
+                .thenReturn(true);
+
+            BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> collectionService.updateCollection(1L, request));
+            assertEquals("Ya tienes una colección con ese nombre", ex.getMessage());
+        }
+    }
+
+    // Verifica que updateCollection con nombre null solo actualiza la descripción.
+    @Test
+    void updateCollection_NullName_OnlyUpdatesDescription() {
+        Long userId = 1L;
+        UpdateCollectionRequest request = new UpdateCollectionRequest();
+        request.setName(null);
+        request.setDescription("Only new description");
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionRepository.save(testCollection)).thenReturn(testCollection);
+
+            ApiResponse result = collectionService.updateCollection(1L, request);
+
+            assertNotNull(result);
+            assertEquals("Colección actualizada con éxito", result.getMessage());
+            verify(collectionRepository, org.mockito.Mockito.never()).existsByNameIgnoreCaseAndAuthorIdAndIdNot(any(), any(), any());
+        }
+    }
+
+    // Verifica que updateCollection con descripción null no sobreescribe la descripción existente.
+    @Test
+    void updateCollection_NullDescription_OnlyUpdatesName() {
+        Long userId = 1L;
+        UpdateCollectionRequest request = new UpdateCollectionRequest();
+        request.setName("New Name");
+        request.setDescription(null);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorIdAndIdNot("New Name", userId, 1L))
+                .thenReturn(false);
+            when(collectionRepository.save(testCollection)).thenReturn(testCollection);
+
+            ApiResponse result = collectionService.updateCollection(1L, request);
+
+            assertNotNull(result);
+            assertEquals("Colección actualizada con éxito", result.getMessage());
+        }
+    }
+
+    // Verifica que updateCollection con el mismo nombre (ignorando mayúsculas) no actualiza el nombre.
+    @Test
+    void updateCollection_SameNameIgnoreCase_SkipsDuplicateCheckAndDoesNotChangeName() {
+        Long userId = 1L;
+        UpdateCollectionRequest request = new UpdateCollectionRequest();
+        request.setName("TEST COLLECTION"); // mismo nombre en mayúsculas
+        request.setDescription("Updated desc");
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionRepository.save(testCollection)).thenReturn(testCollection);
+
+            ApiResponse result = collectionService.updateCollection(1L, request);
+
+            assertNotNull(result);
+            verify(collectionRepository, org.mockito.Mockito.never()).existsByNameIgnoreCaseAndAuthorIdAndIdNot(any(), any(), any());
+        }
+    }
+
+    // Verifica que getCollectionPosts lanza ResourceNotFoundException cuando la colección no existe.
+    @Test
+    void getCollectionPosts_CollectionNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(99L, userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.getCollectionPosts(99L));
+        }
+    }
+
+    // Verifica que getCollectionPosts mapea correctamente un post con verificador externo.
+    @Test
+    void getCollectionPosts_PostWithExternalVerifier_MapsVerifiedBy() {
+        Long userId = 1L;
+        User verifierUser = new User();
+        verifierUser.setId(2L);
+        verifierUser.setProfileUsername("verifier");
+        verifierUser.setRole(UserRole.INSTITUTION);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionPostRepository.findByCollectionIdOrderByAddedAtDesc(1L))
+                .thenReturn(List.of(testCollectionPost));
+            when(verificationQueryService.isPostVerified(testPost)).thenReturn(true);
+            when(verificationQueryService.getExternalVerifier(testPost.getId())).thenReturn(verifierUser);
+
+            List<com.mypresentpast.backend.dto.response.PostResponse> result =
+                collectionService.getCollectionPosts(1L);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertNotNull(result.get(0).getVerifiedBy());
+            assertEquals(2L, result.get(0).getVerifiedBy().getId());
+        }
+    }
+
+    // Verifica que getCollectionPosts mapea correctamente un post con ubicación.
+    @Test
+    void getCollectionPosts_PostWithLocation_MapsLocation() {
+        Long userId = 1L;
+        Location location = new Location();
+        location.setId(10L);
+        location.setAddress("Test Street 123");
+        location.setLatitude(-34.6037);
+        location.setLongitude(-58.3816);
+        testPost.setLocation(location);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionPostRepository.findByCollectionIdOrderByAddedAtDesc(1L))
+                .thenReturn(List.of(testCollectionPost));
+            when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
+            when(verificationQueryService.getExternalVerifier(testPost.getId())).thenReturn(null);
+
+            List<com.mypresentpast.backend.dto.response.PostResponse> result =
+                collectionService.getCollectionPosts(1L);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertNotNull(result.get(0).getLocation());
+            assertEquals("Test Street 123", result.get(0).getLocation().getAddress());
+        }
+    }
+
+    // Verifica que getCollectionPosts mapea correctamente un post con media adjunta.
+    @Test
+    void getCollectionPosts_PostWithMedia_MapsMedia() {
+        Long userId = 1L;
+        Media media = new Media();
+        media.setId(5L);
+        media.setType(MediaType.IMAGE);
+        media.setUrl("https://cloudinary.com/img.jpg");
+        testPost.setMedia(List.of(media));
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionPostRepository.findByCollectionIdOrderByAddedAtDesc(1L))
+                .thenReturn(List.of(testCollectionPost));
+            when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
+            when(verificationQueryService.getExternalVerifier(testPost.getId())).thenReturn(null);
+
+            List<com.mypresentpast.backend.dto.response.PostResponse> result =
+                collectionService.getCollectionPosts(1L);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertNotNull(result.get(0).getMedia());
+            assertEquals(1, result.get(0).getMedia().size());
+            assertEquals("https://cloudinary.com/img.jpg", result.get(0).getMedia().get(0).getUrl());
+        }
+    }
+
+    // Verifica que getPostCollectionStatus lanza ResourceNotFoundException cuando el post no existe.
+    @Test
+    void getPostCollectionStatus_PostNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(postRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.getPostCollectionStatus(99L));
+        }
+    }
+
+    // Verifica que getPostCollectionStatus lanza BadRequestException cuando el post no está activo.
+    @Test
+    void getPostCollectionStatus_PostNotActive_ThrowsBadRequestException() {
+        Long userId = 1L;
+        testPost.setStatus(PostStatus.DELETED);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+
+            assertThrows(BadRequestException.class,
+                () -> collectionService.getPostCollectionStatus(1L));
+        }
+    }
+
+    // Verifica que addPostToCollection lanza ResourceNotFoundException cuando la colección no existe.
+    @Test
+    void addPostToCollection_CollectionNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(99L, userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.addPostToCollection(99L, 1L));
+        }
+    }
+
+    // Verifica que addPostToCollection lanza ResourceNotFoundException cuando el post no existe.
+    @Test
+    void addPostToCollection_PostNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(postRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.addPostToCollection(1L, 99L));
+        }
+    }
+
+    // Verifica que addPostToCollection lanza BadRequestException cuando el post no está activo.
+    @Test
+    void addPostToCollection_PostNotActive_ThrowsBadRequestException() {
+        Long userId = 1L;
+        testPost.setStatus(PostStatus.DISABLED);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+
+            assertThrows(BadRequestException.class,
+                () -> collectionService.addPostToCollection(1L, 1L));
+        }
+    }
+
+    // Verifica que removePostFromCollection lanza ResourceNotFoundException cuando la colección no existe.
+    @Test
+    void removePostFromCollection_CollectionNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(99L, userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.removePostFromCollection(99L, 1L));
+        }
+    }
+
+    // Verifica que removePostFromCollection lanza ResourceNotFoundException cuando el post no está en la colección.
+    @Test
+    void removePostFromCollection_PostNotInCollection_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.findByIdAndAuthorId(1L, userId)).thenReturn(Optional.of(testCollection));
+            when(collectionPostRepository.findByCollectionIdAndPostId(1L, 99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.removePostFromCollection(1L, 99L));
+        }
+    }
+
+    // Verifica que createCollection lanza ResourceNotFoundException cuando el usuario no existe en la base.
+    @Test
+    void createCollection_UserNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+        CreateCollectionRequest request = new CreateCollectionRequest();
+        request.setName("New Collection");
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(0L);
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorId("New Collection", userId)).thenReturn(false);
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.createCollection(request));
+        }
+    }
+
+    // Verifica que createCollectionAndSavePost lanza BadRequestException cuando se alcanza el límite de colecciones.
+    @Test
+    void createCollectionAndSavePost_MaxCollectionsReached_ThrowsBadRequestException() {
+        Long userId = 1L;
+        CreateCollectionAndSavePostRequest request = new CreateCollectionAndSavePostRequest();
+        request.setName("New");
+        request.setPostId(1L);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(20L);
+
+            assertThrows(BadRequestException.class,
+                () -> collectionService.createCollectionAndSavePost(request));
+        }
+    }
+
+    // Verifica que createCollectionAndSavePost lanza BadRequestException cuando el nombre ya existe.
+    @Test
+    void createCollectionAndSavePost_DuplicateName_ThrowsBadRequestException() {
+        Long userId = 1L;
+        CreateCollectionAndSavePostRequest request = new CreateCollectionAndSavePostRequest();
+        request.setName("Existing");
+        request.setPostId(1L);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(0L);
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorId("Existing", userId)).thenReturn(true);
+
+            assertThrows(BadRequestException.class,
+                () -> collectionService.createCollectionAndSavePost(request));
+        }
+    }
+
+    // Verifica que createCollectionAndSavePost lanza ResourceNotFoundException cuando el post no existe.
+    @Test
+    void createCollectionAndSavePost_PostNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+        CreateCollectionAndSavePostRequest request = new CreateCollectionAndSavePostRequest();
+        request.setName("New");
+        request.setPostId(99L);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(0L);
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorId("New", userId)).thenReturn(false);
+            when(postRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.createCollectionAndSavePost(request));
+        }
+    }
+
+    // Verifica que createCollectionAndSavePost lanza BadRequestException cuando el post no está activo.
+    @Test
+    void createCollectionAndSavePost_PostNotActive_ThrowsBadRequestException() {
+        Long userId = 1L;
+        testPost.setStatus(PostStatus.DELETED);
+        CreateCollectionAndSavePostRequest request = new CreateCollectionAndSavePostRequest();
+        request.setName("New");
+        request.setPostId(1L);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(0L);
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorId("New", userId)).thenReturn(false);
+            when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+
+            assertThrows(BadRequestException.class,
+                () -> collectionService.createCollectionAndSavePost(request));
+        }
+    }
+
+    // Verifica que createCollectionAndSavePost lanza ResourceNotFoundException cuando el usuario no existe.
+    @Test
+    void createCollectionAndSavePost_UserNotFound_ThrowsResourceNotFoundException() {
+        Long userId = 1L;
+        CreateCollectionAndSavePostRequest request = new CreateCollectionAndSavePostRequest();
+        request.setName("New");
+        request.setPostId(1L);
+
+        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> mockedSecurity =
+             Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
+
+            mockedSecurity.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId)
+                         .thenReturn(userId);
+            when(collectionRepository.countByAuthorId(userId)).thenReturn(0L);
+            when(collectionRepository.existsByNameIgnoreCaseAndAuthorId("New", userId)).thenReturn(false);
+            when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                () -> collectionService.createCollectionAndSavePost(request));
         }
     }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/FollowServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/FollowServiceImplTest.java
@@ -1,117 +1,384 @@
 package com.mypresentpast.backend.service.impl;
 
 import com.mypresentpast.backend.dto.UserDto;
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.dto.response.FollowStatsResponse;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.model.Follow;
 import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
 import com.mypresentpast.backend.repository.FollowRepository;
+import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.utils.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FollowServiceImplTest {
 
+    // ── Mocks ──────────────────────────────────────────────────────────────
     @Mock
     private FollowRepository followRepository;
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private FollowServiceImpl followService;
 
-    @Test
-    void getFollowingByUserId_validUserId_returnsMappedList() {
-        Long userId = 42L;
+    // ── Datos de test reutilizables ────────────────────────────────────────
+    private User testUser;
+    private User followeeUser;
 
-        User user1 = new User();
-        user1.setId(1L);
-        user1.setProfileUsername("alice");
+    // ── Setup ──────────────────────────────────────────────────────────────
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setProfileUsername("currentuser");
+        testUser.setRole(UserRole.NORMAL);
+        testUser.setAvatar("avatar1.png");
 
-        User user2 = new User();
-        user2.setId(2L);
-        user2.setProfileUsername("bob");
-
-        List<User> repoResult = List.of(user1, user2);
-        when(followRepository.findFollowingByUserId(userId)).thenReturn(repoResult);
-
-        List<UserDto> result = followService.getFollowingByUserId(userId);
-
-        // Assertions con JUnit
-        assertNotNull(result);
-        assertEquals(2, result.size());
-
-        UserDto dto1 = result.get(0);
-        assertEquals(1L, dto1.getId());
-        assertEquals("alice", dto1.getName());
-
-        UserDto dto2 = result.get(1);
-        assertEquals(2L, dto2.getId());
-        assertEquals("bob", dto2.getName());
-
-        // Verificación del repo
-        verify(followRepository).findFollowingByUserId(userId);
+        followeeUser = new User();
+        followeeUser.setId(2L);
+        followeeUser.setProfileUsername("john_doe");
+        followeeUser.setRole(UserRole.NORMAL);
+        followeeUser.setAvatar("avatar2.png");
     }
 
+    // ── follow ─────────────────────────────────────────────────────────────
 
+    // Verifica que seguir a un usuario válido persiste la relación y retorna el mensaje correcto.
     @Test
-    void getFollowingByUserId_userWithoutFollowing_returnsEmptyList() {
-        Long userId = 99L;
-        when(followRepository.findFollowingByUserId(userId)).thenReturn(List.of());
+    void follow_ValidRequest_SavesFollowAndReturnsMessage() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
 
-        List<UserDto> result = followService.getFollowingByUserId(userId);
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(false);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+            Follow expectedFollow = Follow.builder()
+                    .follower(testUser)
+                    .followee(followeeUser)
+                    .build();
+
+            ApiResponse response = followService.follow(2L);
+
+            assertNotNull(response);
+            assertEquals("Ahora sigues a " + followeeUser.getProfileUsername(), response.getMessage());
+            verify(followRepository).save(refEq(expectedFollow, "id"));
+        }
+    }
+
+    // Verifica que un usuario no puede seguirse a sí mismo.
+    @Test
+    void follow_SelfFollow_ThrowsIllegalArgumentException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            assertThrows(IllegalArgumentException.class, () -> followService.follow(1L));
+
+            verify(followRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que seguir a un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void follow_FolloweeNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> followService.follow(2L));
+
+            verify(followRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que no se puede seguir a un usuario que ya se sigue.
+    @Test
+    void follow_AlreadyFollowing_ThrowsIllegalArgumentException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(true);
+
+            assertThrows(IllegalArgumentException.class, () -> followService.follow(2L));
+
+            verify(followRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que si el usuario actual no existe en la DB se lanza ResourceNotFoundException.
+    @Test
+    void follow_CurrentUserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(false);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> followService.follow(2L));
+
+            verify(followRepository, never()).save(any());
+        }
+    }
+
+    // ── unfollow ───────────────────────────────────────────────────────────
+
+    // Verifica que dejar de seguir a un usuario elimina la relación y retorna el mensaje correcto.
+    @Test
+    void unfollow_ValidRequest_DeletesFollowAndReturnsMessage() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            Follow existingFollow = Follow.builder().id(10L).follower(testUser).followee(followeeUser).build();
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.findByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(Optional.of(existingFollow));
+
+            ApiResponse response = followService.unfollow(2L);
+
+            assertNotNull(response);
+            assertEquals("Ya no sigues a " + followeeUser.getProfileUsername(), response.getMessage());
+            verify(followRepository).delete(existingFollow);
+        }
+    }
+
+    // Verifica que dejar de seguir a un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void unfollow_FolloweeNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> followService.unfollow(2L));
+
+            verify(followRepository, never()).delete(any());
+        }
+    }
+
+    // Verifica que no se puede dejar de seguir a alguien que no se sigue.
+    @Test
+    void unfollow_NotFollowing_ThrowsIllegalArgumentException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.findByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(Optional.empty());
+
+            assertThrows(IllegalArgumentException.class, () -> followService.unfollow(2L));
+
+            verify(followRepository, never()).delete(any());
+        }
+    }
+
+    // ── getMyFollowing ─────────────────────────────────────────────────────
+
+    // Verifica que se retornan los usuarios seguidos del usuario actual correctamente mapeados a DTOs.
+    @Test
+    void getMyFollowing_WithFollowing_ReturnsMappedDtoList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.findFollowingByUserId(1L)).thenReturn(List.of(followeeUser));
+
+            List<UserDto> result = followService.getMyFollowing();
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals(2L, result.get(0).getId());
+            assertEquals("john_doe", result.get(0).getName());
+            verify(followRepository).findFollowingByUserId(1L);
+        }
+    }
+
+    // Verifica que si el usuario no sigue a nadie se retorna una lista vacía.
+    @Test
+    void getMyFollowing_NoFollowing_ReturnsEmptyList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.findFollowingByUserId(1L)).thenReturn(List.of());
+
+            List<UserDto> result = followService.getMyFollowing();
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // ── getMyFollowers ─────────────────────────────────────────────────────
+
+    // Verifica que se retornan los seguidores del usuario actual correctamente mapeados a DTOs.
+    @Test
+    void getMyFollowers_WithFollowers_ReturnsMappedDtoList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.findFollowersByUserId(1L)).thenReturn(List.of(followeeUser));
+
+            List<UserDto> result = followService.getMyFollowers();
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals(2L, result.get(0).getId());
+            assertEquals("john_doe", result.get(0).getName());
+            verify(followRepository).findFollowersByUserId(1L);
+        }
+    }
+
+    // Verifica que si el usuario no tiene seguidores se retorna una lista vacía.
+    @Test
+    void getMyFollowers_NoFollowers_ReturnsEmptyList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.findFollowersByUserId(1L)).thenReturn(List.of());
+
+            List<UserDto> result = followService.getMyFollowers();
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // ── isFollowing ────────────────────────────────────────────────────────
+
+    // Verifica que retorna true cuando el usuario actual sigue al usuario consultado.
+    @Test
+    void isFollowing_WhenFollowing_ReturnsTrue() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(true);
+
+            Boolean result = followService.isFollowing(2L);
+
+            assertTrue(result);
+            verify(followRepository).existsByFollowerIdAndFolloweeId(1L, 2L);
+        }
+    }
+
+    // Verifica que retorna false cuando el usuario actual no sigue al usuario consultado.
+    @Test
+    void isFollowing_WhenNotFollowing_ReturnsFalse() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(false);
+
+            Boolean result = followService.isFollowing(2L);
+
+            assertFalse(result);
+        }
+    }
+
+    // ── getFollowStats ─────────────────────────────────────────────────────
+
+    // Verifica que se retornan las estadísticas de seguimiento correctas para un usuario existente.
+    @Test
+    void getFollowStats_ValidUser_ReturnsCorrectStats() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(2L)).thenReturn(Optional.of(followeeUser));
+            when(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).thenReturn(true);
+            when(followRepository.countByFolloweeId(2L)).thenReturn(5L);
+            when(followRepository.countByFollowerId(2L)).thenReturn(3L);
+
+            FollowStatsResponse response = followService.getFollowStats(2L);
+
+            assertNotNull(response);
+            assertEquals(2L, response.getUserId());
+            assertEquals("john_doe", response.getProfileUsername());
+            assertEquals(5L, response.getFollowersCount());
+            assertEquals(3L, response.getFollowingCount());
+            assertTrue(response.isFollowing());
+        }
+    }
+
+    // Verifica que consultar estadísticas de un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void getFollowStats_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> followService.getFollowStats(99L));
+        }
+    }
+
+    // ── getFollowingByUserId (tests existentes) ────────────────────────────
+
+    // Verifica que los usuarios seguidos por un userId dado se retornan correctamente mapeados a DTOs.
+    @Test
+    void getFollowingByUserId_ValidUserId_ReturnsMappedDtoList() {
+        when(followRepository.findFollowingByUserId(1L)).thenReturn(List.of(testUser, followeeUser));
+
+        List<UserDto> result = followService.getFollowingByUserId(1L);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("currentuser", result.get(0).getName());
+        assertEquals(2L, result.get(1).getId());
+        assertEquals("john_doe", result.get(1).getName());
+        verify(followRepository).findFollowingByUserId(1L);
+    }
+
+    // Verifica que si el usuario no sigue a nadie se retorna una lista vacía.
+    @Test
+    void getFollowingByUserId_NoFollowing_ReturnsEmptyList() {
+        when(followRepository.findFollowingByUserId(1L)).thenReturn(List.of());
+
+        List<UserDto> result = followService.getFollowingByUserId(1L);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
-
-        verify(followRepository).findFollowingByUserId(userId);
+        verify(followRepository).findFollowingByUserId(1L);
     }
 
+    // Verifica que los seguidores de un userId dado se retornan correctamente mapeados a DTOs.
     @Test
-    void getFollowersByUserId_validUserId_returnsMappedList() {
-        Long userId = 7L;
+    void getFollowersByUserId_ValidUserId_ReturnsMappedDtoList() {
+        when(followRepository.findFollowersByUserId(1L)).thenReturn(List.of(testUser, followeeUser));
 
-        User u1 = new User();
-        u1.setId(10L);
-        u1.setProfileUsername("carol");
-
-        User u2 = new User();
-        u2.setId(11L);
-        u2.setProfileUsername("dave");
-
-        when(followRepository.findFollowersByUserId(userId)).thenReturn(List.of(u1, u2));
-
-        List<UserDto> result = followService.getFollowersByUserId(userId);
+        List<UserDto> result = followService.getFollowersByUserId(1L);
 
         assertNotNull(result);
         assertEquals(2, result.size());
-
-        UserDto dto1 = result.get(0);
-        assertEquals(10L, dto1.getId());
-        assertEquals("carol", dto1.getName());
-
-        UserDto dto2 = result.get(1);
-        assertEquals(11L, dto2.getId());
-        assertEquals("dave", dto2.getName());
-
-        verify(followRepository).findFollowersByUserId(userId);
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("currentuser", result.get(0).getName());
+        assertEquals(2L, result.get(1).getId());
+        assertEquals("john_doe", result.get(1).getName());
+        verify(followRepository).findFollowersByUserId(1L);
     }
 
+    // Verifica que si el usuario no tiene seguidores se retorna una lista vacía.
     @Test
-    void getFollowersByUserId_userWithoutFollowers_returnsEmptyList() {
-        Long userId = 123L;
-        when(followRepository.findFollowersByUserId(userId)).thenReturn(List.of());
+    void getFollowersByUserId_NoFollowers_ReturnsEmptyList() {
+        when(followRepository.findFollowersByUserId(1L)).thenReturn(List.of());
 
-        List<UserDto> result = followService.getFollowersByUserId(userId);
+        List<UserDto> result = followService.getFollowersByUserId(1L);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
-
-        verify(followRepository).findFollowersByUserId(userId);
+        verify(followRepository).findFollowersByUserId(1L);
     }
-
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/InstitutionRequestServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/InstitutionRequestServiceImplTest.java
@@ -1,0 +1,380 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.request.CreateInstitutionRequestDto;
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.dto.response.InstitutionRequestResponse;
+import com.mypresentpast.backend.enums.InstitutionType;
+import com.mypresentpast.backend.enums.RequestStatus;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.model.InstitutionRequest;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
+import com.mypresentpast.backend.repository.InstitutionRequestRepository;
+import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.service.CloudinaryService;
+import com.mypresentpast.backend.utils.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InstitutionRequestServiceImplTest {
+
+    // ── Mocks ──────────────────────────────────────────────────────────────
+    @Mock
+    private InstitutionRequestRepository institutionRequestRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CloudinaryService cloudinaryService;
+
+    @InjectMocks
+    private InstitutionRequestServiceImpl institutionRequestService;
+
+    // ── Datos de test reutilizables ────────────────────────────────────────
+    private User testUser;
+    private InstitutionRequest testInstitutionRequest;
+    private CreateInstitutionRequestDto testRequestDto;
+
+    // ── Setup ──────────────────────────────────────────────────────────────
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setProfileUsername("testuser");
+        testUser.setRole(UserRole.NORMAL);
+        testUser.setEmailVerified(true);
+
+        testInstitutionRequest = InstitutionRequest.builder()
+                .id(10L)
+                .user(testUser)
+                .institutionName("Museo Nacional")
+                .legalAddress("Av. Siempre Viva 742, Springfield")
+                .officialPhone("+5491112345678")
+                .type(InstitutionType.MUSEUM)
+                .status(RequestStatus.PENDING)
+                .createdAt(LocalDateTime.of(2026, 1, 15, 10, 0))
+                .build();
+
+        testRequestDto = CreateInstitutionRequestDto.builder()
+                .institutionName("Museo Nacional")
+                .legalAddress("Av. Siempre Viva 742, Springfield")
+                .officialPhone("+5491112345678")
+                .type(InstitutionType.MUSEUM)
+                .build();
+    }
+
+    // ── getMyRequests ──────────────────────────────────────────────────────
+
+    // Verifica que las solicitudes del usuario actual se retornan correctamente mapeadas a DTOs.
+    @Test
+    void getMyRequests_WithRequests_ReturnsMappedResponseList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(institutionRequestRepository.findByUserIdOrderByCreatedAtDesc(1L))
+                    .thenReturn(List.of(testInstitutionRequest));
+
+            List<InstitutionRequestResponse> result = institutionRequestService.getMyRequests();
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals(10L, result.get(0).getId());
+            assertEquals("Museo Nacional", result.get(0).getInstitutionName());
+            assertEquals(RequestStatus.PENDING, result.get(0).getStatus());
+            verify(institutionRequestRepository).findByUserIdOrderByCreatedAtDesc(1L);
+        }
+    }
+
+    // Verifica que si el usuario no tiene solicitudes se retorna una lista vacía.
+    @Test
+    void getMyRequests_NoRequests_ReturnsEmptyList() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(institutionRequestRepository.findByUserIdOrderByCreatedAtDesc(1L))
+                    .thenReturn(List.of());
+
+            List<InstitutionRequestResponse> result = institutionRequestService.getMyRequests();
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // ── createRequest ──────────────────────────────────────────────────────
+
+    // Verifica que una solicitud válida se persiste correctamente y retorna el mensaje de éxito.
+    @Test
+    void createRequest_ValidRequest_SavesAndReturnsSuccessMessage() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            MultipartFile document = validDocumentMock();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+            when(cloudinaryService.upload(eq(document), any(Map.class)))
+                    .thenReturn(Map.of("url", "https://cloudinary.com/doc.pdf"));
+
+            ApiResponse response = institutionRequestService.createRequest(testRequestDto, document);
+
+            assertNotNull(response);
+            assertTrue(response.getMessage().contains("creada exitosamente"));
+
+            ArgumentCaptor<InstitutionRequest> captor = ArgumentCaptor.forClass(InstitutionRequest.class);
+            verify(institutionRequestRepository).save(captor.capture());
+            InstitutionRequest saved = captor.getValue();
+            assertEquals(testUser, saved.getUser());
+            assertEquals("Museo Nacional", saved.getInstitutionName());
+            assertEquals("https://cloudinary.com/doc.pdf", saved.getDocumentUrl());
+            assertEquals(RequestStatus.PENDING, saved.getStatus());
+            assertNotNull(saved.getCreatedAt());
+        }
+    }
+
+    // Verifica que si el usuario actual no existe en la DB se lanza ResourceNotFoundException.
+    @Test
+    void createRequest_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, mock(MultipartFile.class)));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que un usuario con rol distinto a NORMAL no puede crear una solicitud.
+    @Test
+    void createRequest_UserNotNormal_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            testUser.setRole(UserRole.INSTITUTION);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, mock(MultipartFile.class)));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que no se puede crear una solicitud si el usuario ya tiene una activa.
+    @Test
+    void createRequest_HasActiveRequest_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(true);
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, mock(MultipartFile.class)));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que pasar un documento nulo lanza BadRequestException.
+    @Test
+    void createRequest_NullDocument_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, null));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que un documento mayor a 5MB lanza BadRequestException.
+    @Test
+    void createRequest_DocumentTooLarge_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+
+            MultipartFile document = mock(MultipartFile.class);
+            when(document.isEmpty()).thenReturn(false);
+            when(document.getSize()).thenReturn(6 * 1024 * 1024L); // 6MB
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, document));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que un documento con tipo de contenido no permitido lanza BadRequestException.
+    @Test
+    void createRequest_InvalidContentType_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+
+            MultipartFile document = mock(MultipartFile.class);
+            when(document.isEmpty()).thenReturn(false);
+            when(document.getSize()).thenReturn(1024L);
+            when(document.getContentType()).thenReturn("text/plain");
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, document));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que un documento sin nombre de archivo lanza BadRequestException.
+    @Test
+    void createRequest_NoFilename_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+
+            MultipartFile document = mock(MultipartFile.class);
+            when(document.isEmpty()).thenReturn(false);
+            when(document.getSize()).thenReturn(1024L);
+            when(document.getContentType()).thenReturn("application/pdf");
+            when(document.getOriginalFilename()).thenReturn("");
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.createRequest(testRequestDto, document));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // ── cancelRequest ──────────────────────────────────────────────────────
+
+    // Verifica que cancelar una solicitud PENDING actualiza su estado a CANCELLED y retorna el mensaje correcto.
+    @Test
+    void cancelRequest_PendingRequest_UpdatesStatusAndReturnsMessage() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(institutionRequestRepository.findByIdAndUserId(10L, 1L))
+                    .thenReturn(Optional.of(testInstitutionRequest));
+
+            ApiResponse response = institutionRequestService.cancelRequest(10L);
+
+            assertNotNull(response);
+            assertTrue(response.getMessage().contains("cancelada exitosamente"));
+            assertEquals(RequestStatus.CANCELLED, testInstitutionRequest.getStatus());
+            assertNotNull(testInstitutionRequest.getReviewedAt());
+            verify(institutionRequestRepository).save(testInstitutionRequest);
+        }
+    }
+
+    // Verifica que cancelar una solicitud inexistente o de otro usuario lanza ResourceNotFoundException.
+    @Test
+    void cancelRequest_RequestNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(institutionRequestRepository.findByIdAndUserId(99L, 1L))
+                    .thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> institutionRequestService.cancelRequest(99L));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que cancelar una solicitud que no está en estado PENDING lanza BadRequestException.
+    @Test
+    void cancelRequest_NotPendingRequest_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            testInstitutionRequest.setStatus(RequestStatus.APPROVED);
+            when(institutionRequestRepository.findByIdAndUserId(10L, 1L))
+                    .thenReturn(Optional.of(testInstitutionRequest));
+
+            assertThrows(BadRequestException.class,
+                    () -> institutionRequestService.cancelRequest(10L));
+
+            verify(institutionRequestRepository, never()).save(any());
+        }
+    }
+
+    // ── canCreateNewRequest ────────────────────────────────────────────────
+
+    // Verifica que un usuario NORMAL sin solicitud activa puede crear una nueva.
+    @Test
+    void canCreateNewRequest_NormalUserWithoutActiveRequest_ReturnsTrue() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(false);
+
+            assertTrue(institutionRequestService.canCreateNewRequest());
+        }
+    }
+
+    // Verifica que un usuario con rol distinto a NORMAL no puede crear una solicitud.
+    @Test
+    void canCreateNewRequest_UserNotNormal_ReturnsFalse() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            testUser.setRole(UserRole.INSTITUTION);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+            assertFalse(institutionRequestService.canCreateNewRequest());
+        }
+    }
+
+    // Verifica que un usuario NORMAL con solicitud activa no puede crear una nueva.
+    @Test
+    void canCreateNewRequest_HasActiveRequest_ReturnsFalse() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(institutionRequestRepository.hasActiveRequest(1L)).thenReturn(true);
+
+            assertFalse(institutionRequestService.canCreateNewRequest());
+        }
+    }
+
+    // Verifica que si el usuario no existe en la DB se retorna false.
+    @Test
+    void canCreateNewRequest_UserNotFound_ReturnsFalse() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertFalse(institutionRequestService.canCreateNewRequest());
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Crea un mock de MultipartFile con datos válidos para el camino feliz.
+     */
+    private MultipartFile validDocumentMock() {
+        MultipartFile document = mock(MultipartFile.class);
+        when(document.isEmpty()).thenReturn(false);
+        when(document.getSize()).thenReturn(1024L);
+        when(document.getContentType()).thenReturn("application/pdf");
+        when(document.getOriginalFilename()).thenReturn("document.pdf");
+        return document;
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/JwtServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/JwtServiceImplTest.java
@@ -1,0 +1,293 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.lang.reflect.Field;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+// JwtServiceImpl no tiene dependencias mockeables: sus campos @Value (secretKey y expirationTimeMs)
+// se inyectan via reflexión en setUp(). Los tokens se generan con el propio servicio en los tests
+// que requieren un token válido, garantizando coherencia entre generación y validación.
+@ExtendWith(MockitoExtension.class)
+class JwtServiceImplTest {
+
+    // Clave Base64 de 256 bits válida para HS256
+    private static final String TEST_SECRET_KEY =
+            "dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLUhTMjU2";
+
+    // 1 hora en milisegundos
+    private static final long TEST_EXPIRATION_MS = 3_600_000L;
+
+    private JwtServiceImpl jwtService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jwtService = new JwtServiceImpl();
+
+        Field secretKeyField = JwtServiceImpl.class.getDeclaredField("secretKey");
+        secretKeyField.setAccessible(true);
+        secretKeyField.set(jwtService, TEST_SECRET_KEY);
+
+        Field expirationField = JwtServiceImpl.class.getDeclaredField("expirationTimeMs");
+        expirationField.setAccessible(true);
+        expirationField.set(jwtService, TEST_EXPIRATION_MS);
+    }
+
+    // ── getToken(UserDetails) ──────────────────────────────────────────────
+
+    // Un JWT válido tiene exactamente tres partes separadas por punto (header.payload.signature).
+    @Test
+    void getToken_ValidUser_ReturnsTokenWithThreeParts() {
+        User user = validUserMock();
+
+        String token = jwtService.getToken(user);
+
+        assertNotNull(token);
+        assertFalse(token.isBlank());
+        assertEquals(3, token.split("\\.").length);
+    }
+
+    // El subject del token debe ser el email del usuario (username de Spring Security).
+    @Test
+    void getToken_ValidUser_SubjectIsUserEmail() {
+        User user = validUserMock();
+
+        String token = jwtService.getToken(user);
+
+        assertEquals("john@example.com", jwtService.getUsernameFromToken(token));
+    }
+
+    // El token debe contener rol, uid, name, lastName y profileUsername del usuario.
+    @Test
+    void getToken_ValidUser_TokenContainsExpectedClaims() {
+        User user = validUserMock();
+
+        String token = jwtService.getToken(user);
+        Claims claims = jwtService.getClaim(token, c -> c);
+
+        assertEquals("NORMAL", claims.get("role", String.class));
+        assertEquals("John", claims.get("name", String.class));
+        assertEquals("Doe", claims.get("lastName", String.class));
+        assertEquals("johndoe", claims.get("profileUsername", String.class));
+    }
+
+    // La fecha de expiración del token debe quedar en el futuro respecto al momento de generación.
+    @Test
+    void getToken_ValidUser_ExpirationIsInTheFuture() {
+        User user = validUserMock();
+
+        String token = jwtService.getToken(user);
+        Date expiration = jwtService.getClaim(token, Claims::getExpiration);
+
+        assertTrue(expiration.after(new Date()));
+    }
+
+    // Pasar un UserDetails que no sea instancia de User debe lanzar IllegalArgumentException.
+    @Test
+    void getToken_NonUserInstance_ThrowsIllegalArgumentException() {
+        UserDetails genericUser = mock(UserDetails.class);
+
+        assertThrows(IllegalArgumentException.class, () -> jwtService.getToken(genericUser));
+    }
+
+    // ── getUsernameFromToken(String) ───────────────────────────────────────
+
+    // Extraer el username de un token válido debe retornar el email del usuario.
+    @Test
+    void getUsernameFromToken_ValidToken_ReturnsEmail() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        String username = jwtService.getUsernameFromToken(token);
+
+        assertEquals("john@example.com", username);
+    }
+
+    // Un token con el último carácter de la firma modificado debe lanzar excepción de JWT.
+    @Test
+    void getUsernameFromToken_TamperedSignature_ThrowsJwtException() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+        String tampered = token.substring(0, token.length() - 1) + "X";
+
+        assertThrows(Exception.class, () -> jwtService.getUsernameFromToken(tampered));
+    }
+
+    // Una cadena que no es un JWT válido debe lanzar excepción al intentar parsear.
+    @Test
+    void getUsernameFromToken_MalformedToken_ThrowsJwtException() {
+        assertThrows(Exception.class, () -> jwtService.getUsernameFromToken("not.a.jwt"));
+    }
+
+    // Un token ya expirado debe lanzar ExpiredJwtException al intentar extraer el username.
+    @Test
+    void getUsernameFromToken_ExpiredToken_ThrowsExpiredJwtException() {
+        String expiredToken = buildExpiredToken("expired@example.com");
+
+        assertThrows(ExpiredJwtException.class, () -> jwtService.getUsernameFromToken(expiredToken));
+    }
+
+    // ── isTokenValid(String, UserDetails) ─────────────────────────────────
+
+    // Un token generado para el usuario debe ser válido cuando el email coincide y no expiró.
+    @Test
+    void isTokenValid_MatchingUserAndFreshToken_ReturnsTrue() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        boolean valid = jwtService.isTokenValid(token, user);
+
+        assertTrue(valid);
+    }
+
+    // Un token generado para un usuario no debe ser válido contra otro email distinto.
+    @Test
+    void isTokenValid_DifferentUserEmail_ReturnsFalse() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        User otherUser = User.builder()
+                .id(99L)
+                .email("other@example.com")
+                .profileUsername("other")
+                .name("Other")
+                .lastName("User")
+                .role(UserRole.NORMAL)
+                .emailVerified(true)
+                .password("pass")
+                .build();
+
+        boolean valid = jwtService.isTokenValid(token, otherUser);
+
+        assertFalse(valid);
+    }
+
+    // Validar un token expirado lanza ExpiredJwtException porque jjwt falla al parsear antes de comparar.
+    @Test
+    void isTokenValid_ExpiredToken_ThrowsExpiredJwtException() {
+        User user = validUserMock();
+        String expiredToken = buildExpiredToken(user.getEmail());
+
+        assertThrows(ExpiredJwtException.class, () -> jwtService.isTokenValid(expiredToken, user));
+    }
+
+    // ── getClaim(String, Function<Claims, T>) ─────────────────────────────
+
+    // El claim iat del token debe ser una fecha reciente (dentro de los últimos 5 segundos).
+    @Test
+    void getClaim_IssuedAtClaim_ReturnsDateCloseToNow() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        Date issuedAt = jwtService.getClaim(token, Claims::getIssuedAt);
+
+        assertNotNull(issuedAt);
+        long diffMs = System.currentTimeMillis() - issuedAt.getTime();
+        assertTrue(diffMs >= 0 && diffMs < 5_000L);
+    }
+
+    // El claim "role" debe retornar el nombre del rol del usuario como String.
+    @Test
+    void getClaim_RoleClaim_ReturnsRoleString() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        String role = jwtService.getClaim(token, claims -> claims.get("role", String.class));
+
+        assertEquals("NORMAL", role);
+    }
+
+    // El claim "profileUsername" debe retornar el alias visible del usuario.
+    @Test
+    void getClaim_ProfileUsernameClaim_ReturnsProfileUsername() {
+        User user = validUserMock();
+        String token = jwtService.getToken(user);
+
+        String profileUsername = jwtService.getClaim(token, claims -> claims.get("profileUsername", String.class));
+
+        assertEquals("johndoe", profileUsername);
+    }
+
+    // Un token firmado con una clave distinta no puede ser parseado con la clave del servicio.
+    @Test
+    void getClaim_TokenSignedWithDifferentKey_ThrowsJwtException() {
+        String tokenWithOtherKey = buildTokenWithDifferentKey("other@example.com");
+
+        assertThrows(Exception.class, () -> jwtService.getClaim(tokenWithOtherKey, Claims::getSubject));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Construye un User completamente poblado con valores fijos para usar en los tests.
+     */
+    private User validUserMock() {
+        return User.builder()
+                .id(42L)
+                .email("john@example.com")
+                .profileUsername("johndoe")
+                .name("John")
+                .lastName("Doe")
+                .role(UserRole.NORMAL)
+                .emailVerified(true)
+                .password("hashedpassword")
+                .build();
+    }
+
+    /**
+     * Genera un token JWT ya expirado usando la misma clave del servicio.
+     */
+    private String buildExpiredToken(String subject) {
+        byte[] keyBytes = Decoders.BASE64.decode(TEST_SECRET_KEY);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("role", "NORMAL");
+        claims.put("uid", 1L);
+        claims.put("name", "Expired");
+        claims.put("lastName", "User");
+        claims.put("profileUsername", "expired");
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis() - 7_200_000L))
+                .setExpiration(new Date(System.currentTimeMillis() - 3_600_000L))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Genera un token JWT firmado con una clave distinta a la configurada en el servicio.
+     */
+    private String buildTokenWithDifferentKey(String subject) {
+        String otherKey = "b3RoZXIta2V5LXRoYXQtaXMtbm90LXRoZS1zYW1lLWFzLXRlc3Qta2V5eA==";
+        byte[] keyBytes = Decoders.BASE64.decode(otherKey);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3_600_000L))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/MediaServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/MediaServiceImplTest.java
@@ -1,0 +1,231 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.MediaDto;
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.enums.MediaType;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.model.Media;
+import com.mypresentpast.backend.repository.MediaRepository;
+import com.mypresentpast.backend.service.CloudinaryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MediaServiceImplTest {
+
+    // ── Mocks ──────────────────────────────────────────────────────────────
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private CloudinaryService cloudinaryService;
+
+    @InjectMocks
+    private MediaServiceImpl mediaService;
+
+    // ── Datos de test reutilizables ────────────────────────────────────────
+    private Media testMedia;
+
+    // ── Setup ──────────────────────────────────────────────────────────────
+    @BeforeEach
+    void setUp() {
+        testMedia = Media.builder()
+                .id(1L)
+                .type(MediaType.IMAGE)
+                .url("https://cloudinary.com/image.jpg")
+                .cloudinaryId("cloudinary_id_123")
+                .post(null)
+                .build();
+    }
+
+    // ── listAvailableMedia ─────────────────────────────────────────────────
+
+    // Verifica que las imágenes disponibles se retornan correctamente mapeadas a DTOs.
+    @Test
+    void listAvailableMedia_WithMedia_ReturnsMappedDtoList() {
+        when(mediaRepository.findAvailableMedia()).thenReturn(List.of(testMedia));
+
+        List<MediaDto> result = mediaService.listAvailableMedia();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals(MediaType.IMAGE, result.get(0).getType());
+        assertEquals("https://cloudinary.com/image.jpg", result.get(0).getUrl());
+        verify(mediaRepository).findAvailableMedia();
+    }
+
+    // Verifica que si no hay imágenes disponibles se retorna una lista vacía.
+    @Test
+    void listAvailableMedia_NoMedia_ReturnsEmptyList() {
+        when(mediaRepository.findAvailableMedia()).thenReturn(List.of());
+
+        List<MediaDto> result = mediaService.listAvailableMedia();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    // ── uploadImage ────────────────────────────────────────────────────────
+
+    // Verifica que una imagen JPEG válida se sube a Cloudinary, se persiste en la BD y se retorna el DTO.
+    @Test
+    void uploadImage_ValidJpegFile_UploadsToCloudinaryAndReturnsDto() {
+        MultipartFile file = validImageMock("image/jpeg");
+        when(cloudinaryService.upload(file))
+                .thenReturn(Map.of("url", "https://cloudinary.com/new.jpg", "public_id", "new_public_id"));
+
+        Media expectedMedia = Media.builder()
+                .type(MediaType.IMAGE)
+                .url("https://cloudinary.com/new.jpg")
+                .cloudinaryId("new_public_id")
+                .post(null)
+                .build();
+        when(mediaRepository.save(refEq(expectedMedia, "id"))).thenReturn(testMedia);
+
+        MediaDto result = mediaService.uploadImage(file);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(MediaType.IMAGE, result.getType());
+        assertEquals("https://cloudinary.com/image.jpg", result.getUrl());
+        verify(cloudinaryService).upload(file);
+        verify(mediaRepository).save(refEq(expectedMedia, "id"));
+    }
+
+    // Verifica que pasar un archivo nulo lanza NullPointerException: el logger llama
+    @Test
+    void uploadImage_NullFile_ThrowsNullPointerException() {
+        // file.getOriginalFilename() antes de llegar a la validación de isValidImage.
+        assertThrows(NullPointerException.class, () -> mediaService.uploadImage(null));
+
+        verify(cloudinaryService, never()).upload(any());
+        verify(mediaRepository, never()).save(any());
+    }
+
+    // Verifica que pasar un archivo vacío lanza IllegalArgumentException.
+    @Test
+    void uploadImage_EmptyFile_ThrowsIllegalArgumentException() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> mediaService.uploadImage(file));
+
+        verify(cloudinaryService, never()).upload(any());
+    }
+
+    // Verifica que un archivo con tipo de contenido no permitido lanza IllegalArgumentException.
+    @Test
+    void uploadImage_InvalidContentType_ThrowsIllegalArgumentException() {
+        MultipartFile file = validImageMock("application/pdf");
+
+        assertThrows(IllegalArgumentException.class, () -> mediaService.uploadImage(file));
+
+        verify(cloudinaryService, never()).upload(any());
+    }
+
+    // ── deleteImage ────────────────────────────────────────────────────────
+
+    // Verifica que eliminar una imagen con cloudinaryId la borra de Cloudinary y de la BD.
+    @Test
+    void deleteImage_WithCloudinaryId_DeletesFromCloudinaryAndDb() {
+        when(mediaRepository.findById(1L)).thenReturn(Optional.of(testMedia));
+
+        ApiResponse response = mediaService.deleteImage(1L);
+
+        assertNotNull(response);
+        assertEquals("Imagen eliminada con éxito", response.getMessage());
+        verify(cloudinaryService).delete("cloudinary_id_123");
+        verify(mediaRepository).delete(testMedia);
+    }
+
+    // Verifica que eliminar una imagen sin cloudinaryId omite Cloudinary y solo borra de la BD.
+    @Test
+    void deleteImage_WithoutCloudinaryId_DeletesOnlyFromDb() {
+        testMedia.setCloudinaryId(null);
+        when(mediaRepository.findById(1L)).thenReturn(Optional.of(testMedia));
+
+        ApiResponse response = mediaService.deleteImage(1L);
+
+        assertNotNull(response);
+        assertEquals("Imagen eliminada con éxito", response.getMessage());
+        verify(cloudinaryService, never()).delete(any());
+        verify(mediaRepository).delete(testMedia);
+    }
+
+    // Verifica que eliminar una imagen inexistente lanza ResourceNotFoundException.
+    @Test
+    void deleteImage_NotFound_ThrowsResourceNotFoundException() {
+        when(mediaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> mediaService.deleteImage(99L));
+
+        verify(cloudinaryService, never()).delete(any());
+        verify(mediaRepository, never()).delete(any());
+    }
+
+    // ── getById ────────────────────────────────────────────────────────────
+
+    // Verifica que buscar una imagen por ID existente retorna la entidad correcta.
+    @Test
+    void getById_ExistingId_ReturnsMedia() {
+        when(mediaRepository.findById(1L)).thenReturn(Optional.of(testMedia));
+
+        Media result = mediaService.getById(1L);
+
+        assertNotNull(result);
+        assertEquals(testMedia, result);
+        verify(mediaRepository).findById(1L);
+    }
+
+    // Verifica que buscar una imagen con ID inexistente lanza ResourceNotFoundException.
+    @Test
+    void getById_NotFound_ThrowsResourceNotFoundException() {
+        when(mediaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> mediaService.getById(99L));
+    }
+
+    // ── existsById ─────────────────────────────────────────────────────────
+
+    // Verifica que existsById retorna true cuando la imagen existe.
+    @Test
+    void existsById_ExistingId_ReturnsTrue() {
+        when(mediaRepository.existsById(1L)).thenReturn(true);
+
+        assertTrue(mediaService.existsById(1L));
+        verify(mediaRepository).existsById(1L);
+    }
+
+    // Verifica que existsById retorna false cuando la imagen no existe.
+    @Test
+    void existsById_NonExistingId_ReturnsFalse() {
+        when(mediaRepository.existsById(99L)).thenReturn(false);
+
+        assertFalse(mediaService.existsById(99L));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Crea un mock de MultipartFile con el contentType dado y isEmpty=false.
+     */
+    private MultipartFile validImageMock(String contentType) {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getContentType()).thenReturn(contentType);
+        return file;
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/PostServiceImplTest.java
@@ -6,9 +6,14 @@ import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.MapResponse;
 import com.mypresentpast.backend.dto.response.PostResponse;
 import com.mypresentpast.backend.enums.Category;
+import com.mypresentpast.backend.enums.MediaType;
 import com.mypresentpast.backend.enums.PostStatus;
 import com.mypresentpast.backend.exception.ResourceNotFoundException;
-import com.mypresentpast.backend.model.*;
+import com.mypresentpast.backend.model.Location;
+import com.mypresentpast.backend.model.Media;
+import com.mypresentpast.backend.model.Post;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
 import com.mypresentpast.backend.repository.LocationRepository;
 import com.mypresentpast.backend.repository.MediaRepository;
 import com.mypresentpast.backend.repository.PostRepository;
@@ -20,6 +25,7 @@ import com.mypresentpast.backend.utils.SecurityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -27,10 +33,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,34 +82,32 @@ class PostServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        // Crear User normal
         testUser = new User();
         testUser.setId(1L);
         testUser.setProfileUsername("testuser");
         testUser.setPassword("password");
+        testUser.setEmail("testuser@example.com");
         testUser.setRole(UserRole.NORMAL);
 
-        // Crear User institución
         institutionUser = new User();
         institutionUser.setId(2L);
         institutionUser.setProfileUsername("institution");
         institutionUser.setPassword("password");
+        institutionUser.setEmail("institution@example.com");
         institutionUser.setRole(UserRole.INSTITUTION);
 
-        // Crear Location
         testLocation = new Location();
         testLocation.setId(1L);
         testLocation.setAddress("Test Address");
         testLocation.setLatitude(-34.6118);
         testLocation.setLongitude(-58.3960);
 
-        // Crear Post
         testPost = new Post();
         testPost.setId(1L);
         testPost.setTitle("Test Post");
         testPost.setContent("Test Content");
-        testPost.setDate(LocalDate.now());
-        testPost.setPostedAt(LocalDate.now());
+        testPost.setDate(LocalDate.of(2024, 6, 15));
+        testPost.setPostedAt(LocalDate.of(2024, 6, 15));
         testPost.setCategory(Category.STORY);
         testPost.setIsByIA(false);
         testPost.setStatus(PostStatus.ACTIVE);
@@ -106,11 +115,10 @@ class PostServiceImplTest {
         testPost.setLocation(testLocation);
         testPost.setMedia(new ArrayList<>());
 
-        // Crear CreatePostRequest
         createRequest = new CreatePostRequest();
         createRequest.setTitle("New Test Post");
         createRequest.setContent("New test content");
-        createRequest.setDate(LocalDate.now());
+        createRequest.setDate(LocalDate.of(2024, 6, 15));
         createRequest.setCategory(Category.STORY);
         createRequest.setIsByIA(false);
         createRequest.setAuthorId(1L);
@@ -119,19 +127,35 @@ class PostServiceImplTest {
         createRequest.setAddress("Buenos Aires, Argentina");
     }
 
+    // ─── helpers privados ────────────────────────────────────────────────────
+
+    private Map<String, Object> validUploadResultMock() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("url", "http://res.cloudinary.com/test/image.jpg");
+        result.put("public_id", "test_public_id_123");
+        return result;
+    }
+
+    private void stubMapToPostResponse(Post post) {
+        when(verificationQueryService.isPostVerified(post)).thenReturn(false);
+        when(verificationQueryService.getExternalVerifier(post.getId())).thenReturn(null);
+        when(likeService.getTotalLikes(post.getId())).thenReturn(0L);
+        when(likeService.isLikedByCurrentUser(post.getId())).thenReturn(false);
+    }
+
+    // ─── createPost ──────────────────────────────────────────────────────────
+
+    // Ubicación no existe en proximidad → se crea una nueva; no hay imágenes
     @Test
-    void createPost_Success_WithoutImages() {
-        // Given
+    void createPost_SinImagenesYUbicacionNueva_RetornaMensajeExito() {
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(locationRepository.findLocationsByProximity(anyDouble(), anyDouble()))
-            .thenReturn(Collections.emptyList());
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.emptyList());
         when(locationRepository.save(any(Location.class))).thenReturn(testLocation);
         when(postRepository.save(any(Post.class))).thenReturn(testPost);
 
-        // When
         ApiResponse response = postService.createPost(createRequest, null);
 
-        // Then
         assertNotNull(response);
         assertEquals("Publicación creada con éxito", response.getMessage());
         verify(userRepository).findById(1L);
@@ -141,88 +165,135 @@ class PostServiceImplTest {
         verify(cloudinaryService, never()).upload(any());
     }
 
+    // Existe una ubicación cercana → se reutiliza sin crear una nueva
     @Test
-    void createPost_Success_WithImages() throws Exception {
-        // Given
-        List<MultipartFile> images = Arrays.asList(mockImage);
-        Map<String, Object> uploadResult = new HashMap<>();
-        uploadResult.put("url", "http://test.com/image.jpg");
-        uploadResult.put("public_id", "test123");
-
+    void createPost_SinImagenesYUbicacionExistente_ReutilizaLocation() {
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(locationRepository.findLocationsByProximity(anyDouble(), anyDouble()))
-            .thenReturn(Collections.emptyList());
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+
+        ApiResponse response = postService.createPost(createRequest, null);
+
+        assertNotNull(response);
+        assertEquals("Publicación creada con éxito", response.getMessage());
+        verify(locationRepository, never()).save(any(Location.class));
+    }
+
+    // Lista de imágenes vacía (distinto a null) → no se sube nada
+    @Test
+    void createPost_ListaImagenesVacia_NoSubeNadaACloudinary() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.emptyList());
         when(locationRepository.save(any(Location.class))).thenReturn(testLocation);
         when(postRepository.save(any(Post.class))).thenReturn(testPost);
-        when(cloudinaryService.upload(any(MultipartFile.class))).thenReturn(uploadResult);
-        when(mediaRepository.saveAll(anyList())).thenReturn(new ArrayList<>());
 
-        // When
-        ApiResponse response = postService.createPost(createRequest, images);
+        ApiResponse response = postService.createPost(createRequest, Collections.emptyList());
 
-        // Then
+        assertNotNull(response);
+        assertEquals("Publicación creada con éxito", response.getMessage());
+        verify(cloudinaryService, never()).upload(any());
+        verify(mediaRepository, never()).saveAll(any());
+    }
+
+    // Una imagen válida → se sube a Cloudinary y se persiste el Media
+    @Test
+    void createPost_ConUnaImagen_SubeACloudinaryYGuardaMedia() throws Exception {
+        Map<String, Object> uploadResult = validUploadResultMock();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.emptyList());
+        when(locationRepository.save(any(Location.class))).thenReturn(testLocation);
+        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+        when(cloudinaryService.upload(mockImage)).thenReturn(uploadResult);
+        when(mediaRepository.saveAll(any())).thenReturn(new ArrayList<>());
+
+        ApiResponse response = postService.createPost(createRequest, Collections.singletonList(mockImage));
+
         assertNotNull(response);
         assertEquals("Publicación creada con éxito", response.getMessage());
         verify(cloudinaryService).upload(mockImage);
-        verify(mediaRepository).saveAll(anyList());
+
+        ArgumentCaptor<List<Media>> mediaCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mediaRepository).saveAll(mediaCaptor.capture());
+        List<Media> savedMedia = mediaCaptor.getValue();
+        assertEquals(1, savedMedia.size());
+        assertEquals("http://res.cloudinary.com/test/image.jpg", savedMedia.get(0).getUrl());
+        assertEquals("test_public_id_123", savedMedia.get(0).getCloudinaryId());
+        assertEquals(MediaType.IMAGE, savedMedia.get(0).getType());
     }
 
+    // Seis imágenes superan el límite de 5 → debe lanzar excepción antes de subir
     @Test
-    void createPost_UserNotFound_ThrowsException() {
-        // Given
-        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+    void createPost_MasDecincoImagenes_LanzaIllegalArgumentException() {
+        List<MultipartFile> seisImagenes = Arrays.asList(
+                mockImage, mockImage, mockImage, mockImage, mockImage, mockImage);
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.createPost(createRequest, null)
-        );
-
-        assertEquals("Usuario no encontrado con id: 1", exception.getMessage());
-    }
-
-    @Test
-    void createPost_WithTooManyImages_ThrowsException() {
-        // Given
-        List<MultipartFile> tooManyImages = Arrays.asList(
-            mockImage, mockImage, mockImage, mockImage, mockImage, mockImage // 6 imágenes
-        );
-
-        // Configurar todos los mocks necesarios hasta llegar a la validación de imágenes
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(locationRepository.findLocationsByProximity(anyDouble(), anyDouble()))
-            .thenReturn(Collections.emptyList());
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.emptyList());
         when(locationRepository.save(any(Location.class))).thenReturn(testLocation);
         when(postRepository.save(any(Post.class))).thenReturn(testPost);
 
-        // When & Then
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> postService.createPost(createRequest, tooManyImages)
-        );
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> postService.createPost(createRequest, seisImagenes));
 
-        assertEquals("Máximo 5 imágenes permitidas por publicación", exception.getMessage());
+        assertEquals("Máximo 5 imágenes permitidas por publicación", ex.getMessage());
+        verify(cloudinaryService, never()).upload(any());
     }
 
+    // Cloudinary lanza excepción al subir → se relanza como RuntimeException
     @Test
-    void getPostById_Success() {
-        // Given
+    void createPost_CloudinaryFalla_LanzaRuntimeException() throws Exception {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.emptyList());
+        when(locationRepository.save(any(Location.class))).thenReturn(testLocation);
+        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+        when(cloudinaryService.upload(mockImage)).thenThrow(new RuntimeException("Timeout de red"));
+
+        List<MultipartFile> images = Collections.singletonList(mockImage);
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> postService.createPost(createRequest, images));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+    }
+
+    // Usuario con id=1 no existe → excepción inmediata
+    @Test
+    void createPost_UsuarioNoExiste_LanzaResourceNotFoundException() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.createPost(createRequest, null));
+
+        assertEquals("Usuario no encontrado con id: 1", ex.getMessage());
+    }
+
+    // ─── getPostById ─────────────────────────────────────────────────────────
+
+    // Post encontrado con autor y ubicación → se mapea correctamente
+    @Test
+    void getPostById_PostExistente_RetornaPostResponse() {
         when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.of(testPost));
-        when(likeService.getTotalLikes(1L)).thenReturn(5L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
         when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
         when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+        when(likeService.getTotalLikes(1L)).thenReturn(5L);
+        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
 
-        // When
         PostResponse response = postService.getPostById(1L);
 
-        // Then
         assertNotNull(response);
         assertEquals("Test Post", response.getTitle());
         assertEquals("Test Content", response.getContent());
-        assertEquals(testUser.getProfileUsername(), response.getAuthor().getName());
+        assertEquals("testuser", response.getAuthor().getName());
         assertEquals(5L, response.getTotalLikes());
-        assertEquals(true, response.getIsLiked());
+        assertTrue(response.getIsLiked());
         verify(postRepository).findByIdWithRelations(1L);
         verify(likeService).getTotalLikes(1L);
         verify(likeService).isLikedByCurrentUser(1L);
@@ -230,226 +301,153 @@ class PostServiceImplTest {
         verify(verificationQueryService).getExternalVerifier(1L);
     }
 
+    // Post verificado con institución externa → verifiedBy se popula en la respuesta
     @Test
-    void getPostById_NotFound_ThrowsException() {
-        // Given
+    void getPostById_PostConVerificador_MapeoVerifiedByCompleto() {
+        when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.of(testPost));
+        when(verificationQueryService.isPostVerified(testPost)).thenReturn(true);
+        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(institutionUser);
+        when(likeService.getTotalLikes(1L)).thenReturn(0L);
+        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
+
+        PostResponse response = postService.getPostById(1L);
+
+        assertNotNull(response.getVerifiedBy());
+        assertEquals(2L, response.getVerifiedBy().getId());
+        assertEquals("institution", response.getVerifiedBy().getName());
+        assertEquals(UserRole.INSTITUTION, response.getVerifiedBy().getType());
+        assertTrue(response.getIsVerified());
+    }
+
+    // Post con dos imágenes → la lista de media se mapea en el response
+    @Test
+    void getPostById_PostConMedia_MapeoMediaCompleto() {
+        Media media1 = new Media();
+        media1.setId(10L);
+        media1.setType(MediaType.IMAGE);
+        media1.setUrl("http://example.com/img1.jpg");
+
+        Media media2 = new Media();
+        media2.setId(11L);
+        media2.setType(MediaType.IMAGE);
+        media2.setUrl("http://example.com/img2.jpg");
+
+        testPost.setMedia(Arrays.asList(media1, media2));
+
+        when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.of(testPost));
+        stubMapToPostResponse(testPost);
+
+        PostResponse response = postService.getPostById(1L);
+
+        assertNotNull(response.getMedia());
+        assertEquals(2, response.getMedia().size());
+        assertEquals(10L, response.getMedia().get(0).getId());
+        assertEquals("http://example.com/img1.jpg", response.getMedia().get(0).getUrl());
+    }
+
+    // Post sin location asignada → el campo location en la respuesta debe ser null
+    @Test
+    void getPostById_PostSinUbicacion_LocationEsNull() {
+        testPost.setLocation(null);
+
+        when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.of(testPost));
+        stubMapToPostResponse(testPost);
+
+        PostResponse response = postService.getPostById(1L);
+
+        assertNull(response.getLocation());
+    }
+
+    // Post sin autor asignado → el campo author en la respuesta debe ser null
+    @Test
+    void getPostById_PostSinAutor_AutorEsNull() {
+        testPost.setAuthor(null);
+
+        when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.of(testPost));
+        stubMapToPostResponse(testPost);
+
+        PostResponse response = postService.getPostById(1L);
+
+        assertNull(response.getAuthor());
+    }
+
+    // Post con id=1 no existe → excepción con mensaje exacto
+    @Test
+    void getPostById_PostNoEncontrado_LanzaResourceNotFoundException() {
         when(postRepository.findByIdWithRelations(1L)).thenReturn(Optional.empty());
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.getPostById(1L)
-        );
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.getPostById(1L));
 
-        assertEquals("Publicación no encontrada con id: 1", exception.getMessage());
+        assertEquals("Publicación no encontrada con id: 1", ex.getMessage());
         verify(postRepository).findByIdWithRelations(1L);
     }
 
-    @Test
-    void getPostsByUser_Success() {
-        // Given
-        List<Post> userPosts = Arrays.asList(testPost);
-        when(postRepository.findByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(userPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(3L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+    // ─── getPostsByUser ───────────────────────────────────────────────────────
 
-        // When
+    // Usuario con posts activos → se devuelven mapeados
+    @Test
+    void getPostsByUser_UsuarioConPosts_RetornaListaDeResponses() {
+        when(postRepository.findByAuthorIdAndStatus(1L, PostStatus.ACTIVE))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
         List<PostResponse> responses = postService.getPostsByUser(1L);
 
-        // Then
         assertNotNull(responses);
         assertEquals(1, responses.size());
         assertEquals("Test Post", responses.get(0).getTitle());
         verify(postRepository).findByAuthorIdAndStatus(1L, PostStatus.ACTIVE);
     }
 
+    // Usuario sin posts activos → excepción con mensaje estándar
     @Test
-    void getPostsByUser_NoPostsFound_ThrowsException() {
-        // Given
-        when(postRepository.findByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(Collections.emptyList());
+    void getPostsByUser_UsuarioSinPosts_LanzaResourceNotFoundException() {
+        when(postRepository.findByAuthorIdAndStatus(1L, PostStatus.ACTIVE))
+                .thenReturn(Collections.emptyList());
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.getPostsByUser(1L)
-        );
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.getPostsByUser(1L));
 
-        assertEquals("No hay publicaciones disponibles para mostrar", exception.getMessage());
+        assertEquals("No hay publicaciones disponibles para mostrar", ex.getMessage());
     }
 
+    // ─── getLikedPostsByCurrentUser ───────────────────────────────────────────
+
+    // Usuario autenticado tiene posts likeados → se mapean y devuelven
     @Test
-    void getMapData_Success_WithAllFilters() {
-        // Given
-        List<Post> mockPosts = Arrays.asList(testPost);
-        List<String> categoryStrings = Arrays.asList("STORY");
-        List<Long> userIds = Arrays.asList(1L);
-        LocalDate testDate = LocalDate.now();
+    void getLikedPostsByCurrentUser_UsuarioConLikes_RetornaListaDeResponses() {
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            mockedSecurity.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
 
-        when(postRepository.findPostsInAreaWithMultipleFilters(
-            eq(-35.0), eq(-34.0), eq(-59.0), eq(-58.0),
-            eq(categoryStrings), eq(testDate), eq(testDate), eq(false), eq(userIds)))
-            .thenReturn(mockPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(8L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(true);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+            when(postRepository.findLikedPostsByUserId(1L))
+                    .thenReturn(Collections.singletonList(testPost));
+            when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
+            when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+            when(likeService.getTotalLikes(1L)).thenReturn(10L);
+            when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
 
-        // When
-        MapResponse response = postService.getMapData(
-            -35.0, -34.0, -59.0, -58.0, "STORY", Arrays.asList("STORY"), testDate, null, null, true, false, 1L, Arrays.asList(1L)
-        );
-
-        // Then
-        assertNotNull(response);
-        assertEquals(1, response.getPosts().size());
-        assertEquals("Test Post", response.getPosts().get(0).getTitle());
-        assertEquals(8L, response.getPosts().get(0).getTotalLikes());
-        assertEquals(true, response.getPosts().get(0).getIsLiked());
-        verify(postRepository).findPostsInAreaWithMultipleFilters(
-            -35.0, -34.0, -59.0, -58.0, categoryStrings, testDate, testDate, false, userIds
-        );
-    }
-
-    @Test
-    void getMapData_Success_WithMinimalParams() {
-        // Given
-        List<Post> mockPosts = Arrays.asList(testPost);
-        when(postRepository.findPostsInAreaWithMultipleFilters(
-            eq(-35.0), eq(-34.0), eq(-59.0), eq(-58.0),
-            anyList(), eq(null), eq(null), eq(null), anyList()))
-            .thenReturn(mockPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(2L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
-
-        // When
-        MapResponse response = postService.getMapData(
-            -35.0, -34.0, -59.0, -58.0, null, null, null, null, null, null, null, null, null
-        );
-
-        // Then
-        assertNotNull(response);
-        assertEquals(1, response.getPosts().size());
-        assertEquals(2L, response.getPosts().get(0).getTotalLikes());
-        assertEquals(false, response.getPosts().get(0).getIsLiked());
-    }
-
-    @Test
-    void getMapData_WithVerifiedFilter() {
-        // Given
-        List<Post> mockPosts = Arrays.asList(testPost);
-        when(postRepository.findPostsInAreaWithMultipleFilters(
-            eq(-35.0), eq(-34.0), eq(-59.0), eq(-58.0),
-            anyList(), eq(null), eq(null), eq(null), anyList()))
-            .thenReturn(mockPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(12L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(true);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(institutionUser);
-
-        // When
-        MapResponse response = postService.getMapData(
-            -35.0, -34.0, -59.0, -58.0, null, null, null, null, null, true, null, null, null
-        );
-
-        // Then
-        assertNotNull(response);
-        assertEquals(1, response.getPosts().size());
-        assertEquals(12L, response.getPosts().get(0).getTotalLikes());
-        assertEquals(true, response.getPosts().get(0).getIsLiked());
-        assertEquals(true, response.getPosts().get(0).getIsVerified());
-    }
-
-    @Test
-    void getMapData_FilterByIA() {
-        // Given
-        List<Post> mockPosts = Arrays.asList(testPost);
-        when(postRepository.findPostsInAreaWithMultipleFilters(
-            eq(-35.0), eq(-34.0), eq(-59.0), eq(-58.0),
-            anyList(), eq(null), eq(null), eq(false), anyList()))
-            .thenReturn(mockPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(7L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
-
-        // When
-        MapResponse response = postService.getMapData(
-            -35.0, -34.0, -59.0, -58.0, null, null, null, null, null, null, false, null, null
-        );
-
-        // Then
-        assertNotNull(response);
-        assertEquals(1, response.getPosts().size());
-        assertEquals(7L, response.getPosts().get(0).getTotalLikes());
-        assertEquals(false, response.getPosts().get(0).getIsLiked());
-    }
-
-    @Test
-    void getMapData_FilterByUser() {
-        // Given
-        List<Post> mockPosts = Arrays.asList(testPost);
-        List<Long> userIds = Arrays.asList(1L);
-
-        when(postRepository.findPostsInAreaWithMultipleFilters(
-            eq(-35.0), eq(-34.0), eq(-59.0), eq(-58.0),
-            anyList(), eq(null), eq(null), eq(null), eq(userIds)))
-            .thenReturn(mockPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(15L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
-
-        // When
-        MapResponse response = postService.getMapData(
-            -35.0, -34.0, -59.0, -58.0, null, null, null, null, null, null, null, 1L, Arrays.asList(1L)
-        );
-
-        // Then
-        assertNotNull(response);
-        assertEquals(1, response.getPosts().size());
-        assertEquals("Test Post", response.getPosts().get(0).getTitle());
-        assertEquals(15L, response.getPosts().get(0).getTotalLikes());
-        assertEquals(true, response.getPosts().get(0).getIsLiked());
-    }
-
-    @Test
-    void getLikedPostsByCurrentUser_Success() {
-        // Given
-        List<Post> likedPosts = Arrays.asList(testPost);
-        when(postRepository.findLikedPostsByUserId(1L)).thenReturn(likedPosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(10L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(true);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
-
-        // When & Then - Mock SecurityUtils
-        try (MockedStatic<SecurityUtils> mockedSecurityUtils = mockStatic(SecurityUtils.class)) {
-            mockedSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
-            
             List<PostResponse> response = postService.getLikedPostsByCurrentUser();
 
             assertNotNull(response);
             assertEquals(1, response.size());
             assertEquals("Test Post", response.get(0).getTitle());
             assertEquals(10L, response.get(0).getTotalLikes());
-            assertEquals(true, response.get(0).getIsLiked());
+            assertTrue(response.get(0).getIsLiked());
             verify(postRepository).findLikedPostsByUserId(1L);
         }
     }
 
+    // Usuario autenticado no tiene ningún post likeado → lista vacía sin excepción
     @Test
-    void getLikedPostsByCurrentUser_NoLikedPosts() {
-        // Given
-        when(postRepository.findLikedPostsByUserId(1L)).thenReturn(new ArrayList<>());
+    void getLikedPostsByCurrentUser_UsuarioSinLikes_RetornaListaVacia() {
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            mockedSecurity.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
 
-        // When & Then - Mock SecurityUtils
-        try (MockedStatic<SecurityUtils> mockedSecurityUtils = mockStatic(SecurityUtils.class)) {
-            mockedSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
-            
+            when(postRepository.findLikedPostsByUserId(1L)).thenReturn(new ArrayList<>());
+
             List<PostResponse> response = postService.getLikedPostsByCurrentUser();
 
             assertNotNull(response);
@@ -458,70 +456,312 @@ class PostServiceImplTest {
         }
     }
 
-    @Test
-    void getRandomPost_Success() {
-        // Given
-        List<Post> activePosts = Arrays.asList(testPost);
-        when(postRepository.findByStatusAndLocationIsNotNull(PostStatus.ACTIVE))
-            .thenReturn(activePosts);
-        when(likeService.getTotalLikes(1L)).thenReturn(3L);
-        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
-        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
-        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+    // ─── getRandomPost ────────────────────────────────────────────────────────
 
-        // When
+    // Hay al menos un post activo con ubicación → se devuelve correctamente
+    @Test
+    void getRandomPost_HayPostsActivos_RetornaUnPost() {
+        when(postRepository.findByStatusAndLocationIsNotNull(PostStatus.ACTIVE))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
         PostResponse response = postService.getRandomPost();
 
-        // Then
         assertNotNull(response);
         assertEquals("Test Post", response.getTitle());
-        assertEquals(3L, response.getTotalLikes());
-        assertEquals(false, response.getIsLiked());
         verify(postRepository).findByStatusAndLocationIsNotNull(PostStatus.ACTIVE);
-        verify(likeService).getTotalLikes(1L);
-        verify(likeService).isLikedByCurrentUser(1L);
     }
 
+    // No existe ningún post activo con ubicación → excepción con mensaje estándar
     @Test
-    void getRandomPost_NoPosts_ThrowsException() {
-        // Given
+    void getRandomPost_NoHayPostsActivos_LanzaResourceNotFoundException() {
         when(postRepository.findByStatusAndLocationIsNotNull(PostStatus.ACTIVE))
-            .thenReturn(Collections.emptyList());
+                .thenReturn(Collections.emptyList());
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.getRandomPost()
-        );
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.getRandomPost());
 
-        assertEquals("No hay publicaciones disponibles para mostrar", exception.getMessage());
+        assertEquals("No hay publicaciones disponibles para mostrar", ex.getMessage());
     }
 
+    // ─── getMapData ───────────────────────────────────────────────────────────
+
+    // Sin filtros opcionales → se delega la query con listas vacías y nulls
     @Test
-    void updatePost_Success() {
-        // Given
-        UpdatePostRequest updateRequest = new UpdatePostRequest();
-        updateRequest.setTitle("Updated Title");
-        updateRequest.setContent("Updated Content");
-        updateRequest.setCategory(Category.INFORMATION);
-        updateRequest.setAuthorId(1L);
-        updateRequest.setLatitude(-34.6118);
-        updateRequest.setLongitude(-58.3960);
-        updateRequest.setAddress("Updated Address");
-        updateRequest.setDate(LocalDate.now());
-        updateRequest.setIsByIA(false);
+    void getMapData_SinFiltros_RetornaTodosLosPostsDelArea() {
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+        assertEquals("Test Post", response.getPosts().get(0).getTitle());
+    }
+
+    // Se envía una sola categoría via parámetro 'category' → se convierte a enum y se pasa a la query
+    @Test
+    void getMapData_ConCategoriaSimple_MapeoACategoryEnum() {
+        List<String> expectedCategories = Collections.singletonList("STORY");
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                expectedCategories, null, null, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                "STORY", null, null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // Se envían tanto 'category' como 'categories' → 'categories' tiene prioridad
+    @Test
+    void getMapData_ConCategoriasMultiples_PriorizaCategoriesOverCategory() {
+        List<String> expectedCategories = Arrays.asList("STORY", "INFORMATION");
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                expectedCategories, null, null, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                "MYTH", Arrays.asList("STORY", "INFORMATION"),
+                null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // Categoría que no existe en el enum → se ignora con warning y la lista queda vacía
+    @Test
+    void getMapData_CategoriaInvalida_SeIgnoraYListaQuedaVacia() {
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, Collections.emptyList()))
+                .thenReturn(Collections.emptyList());
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                "CATEGORIA_INEXISTENTE", null,
+                null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertTrue(response.getPosts().isEmpty());
+    }
+
+    // Solo se envía 'date' sin dateFrom/dateTo → dateFrom y dateTo toman el mismo valor
+    @Test
+    void getMapData_ConFechaSimple_CreoRangoConMismaFechaParaAmbosBound() {
+        LocalDate fecha = LocalDate.of(2024, 3, 15);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), fecha, fecha, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, fecha, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+        verify(postRepository).findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), fecha, fecha, null, Collections.emptyList());
+    }
+
+    // Se pasan dateFrom y dateTo explícitos → se usan sin modificar
+    @Test
+    void getMapData_ConDateFromYDateTo_UsaRangoExplicito() {
+        LocalDate from = LocalDate.of(2024, 1, 1);
+        LocalDate to = LocalDate.of(2024, 12, 31);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), from, to, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, from, to, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // Se envía userId individual pero no userIds → se agrega ese id a la lista
+    @Test
+    void getMapData_ConUserIdSinUserIds_AgregaUserIdALaLista() {
+        List<Long> expectedUserIds = Collections.singletonList(1L);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, expectedUserIds))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, null, null, null, null, 1L, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // Se envían tanto userId como userIds → userIds tiene prioridad
+    @Test
+    void getMapData_ConUserIds_PriorizaUserIdsOverUserId() {
+        List<Long> expectedUserIds = Arrays.asList(1L, 2L);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, expectedUserIds))
+                .thenReturn(Collections.singletonList(testPost));
+        stubMapToPostResponse(testPost);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, null, null, null, null, 99L, Arrays.asList(1L, 2L));
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // isVerified=true → solo pasan posts cuyo estado de verificación es true
+    @Test
+    void getMapData_FiltroIsVerifiedTrue_ExcluyePostsNoVerificados() {
+        Post postNoVerificado = new Post();
+        postNoVerificado.setId(2L);
+        postNoVerificado.setTitle("Post No Verificado");
+        postNoVerificado.setAuthor(testUser);
+        postNoVerificado.setLocation(testLocation);
+        postNoVerificado.setMedia(new ArrayList<>());
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, Collections.emptyList()))
+                .thenReturn(Arrays.asList(testPost, postNoVerificado));
+
+        when(verificationQueryService.isPostVerified(testPost)).thenReturn(true);
+        when(verificationQueryService.isPostVerified(postNoVerificado)).thenReturn(false);
+        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+        when(likeService.getTotalLikes(1L)).thenReturn(0L);
+        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, null, null, true, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+        assertEquals("Test Post", response.getPosts().get(0).getTitle());
+        assertTrue(response.getPosts().get(0).getIsVerified());
+    }
+
+    // isVerified=null → no se aplica filtro; todos los posts del área se incluyen
+    @Test
+    void getMapData_FiltroIsVerifiedNull_NoFiltroDeVerificacion() {
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), null, null, null, Collections.emptyList()))
+                .thenReturn(Collections.singletonList(testPost));
+        when(verificationQueryService.isPostVerified(testPost)).thenReturn(false);
+        when(verificationQueryService.getExternalVerifier(1L)).thenReturn(null);
+        when(likeService.getTotalLikes(1L)).thenReturn(0L);
+        when(likeService.isLikedByCurrentUser(1L)).thenReturn(false);
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.getPosts().size());
+    }
+
+    // Query principal devuelve vacío con rango de fechas → se ejecuta la query de debug sobre findAll
+    @Test
+    void getMapData_ResultadoVacioConFiltroFecha_EjecutaDebugQuery() {
+        LocalDate from = LocalDate.of(2024, 6, 15);
+        LocalDate to = LocalDate.of(2024, 6, 15);
+
+        Post postActivo = new Post();
+        postActivo.setId(5L);
+        postActivo.setStatus(PostStatus.ACTIVE);
+        postActivo.setDate(LocalDate.of(2024, 6, 15));
+        postActivo.setLocation(testLocation);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), from, to, null, Collections.emptyList()))
+                .thenReturn(Collections.emptyList());
+        when(postRepository.findAll()).thenReturn(Collections.singletonList(postActivo));
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, from, to, null, null, null, null);
+
+        assertNotNull(response);
+        assertTrue(response.getPosts().isEmpty());
+        verify(postRepository).findAll();
+    }
+
+    // Post en rango de fecha pero sin ubicación → rama debug que loguea "SIN UBICACIÓN"
+    @Test
+    void getMapData_ResultadoVacioConFiltroFechaYPostSinLocation_RamaDebugSinLocation() {
+        LocalDate from = LocalDate.of(2024, 6, 15);
+        LocalDate to = LocalDate.of(2024, 6, 15);
+
+        Post postSinLocation = new Post();
+        postSinLocation.setId(6L);
+        postSinLocation.setStatus(PostStatus.ACTIVE);
+        postSinLocation.setDate(LocalDate.of(2024, 6, 15));
+        postSinLocation.setLocation(null);
+
+        when(postRepository.findPostsInAreaWithMultipleFilters(
+                -35.0, -34.0, -59.0, -58.0,
+                Collections.emptyList(), from, to, null, Collections.emptyList()))
+                .thenReturn(Collections.emptyList());
+        when(postRepository.findAll()).thenReturn(Collections.singletonList(postSinLocation));
+
+        MapResponse response = postService.getMapData(
+                -35.0, -34.0, -59.0, -58.0,
+                null, null, null, from, to, null, null, null, null);
+
+        assertNotNull(response);
+        assertTrue(response.getPosts().isEmpty());
+        verify(postRepository).findAll();
+    }
+
+    // ─── updatePost ───────────────────────────────────────────────────────────
+
+    // Post y autor existen; ubicación ya existe en proximidad; no hay imágenes nuevas
+    @Test
+    void updatePost_ActualizacionExitosaSinImagenesNuevas_RetornaMensajeExito() {
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
         updateRequest.setKeepImageIds(new ArrayList<>());
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(locationRepository.findLocationsByProximity(anyDouble(), anyDouble()))
-            .thenReturn(Arrays.asList(testLocation));
-        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(postRepository.save(testPost)).thenReturn(testPost);
 
-        // When
         ApiResponse response = postService.updatePost(1L, updateRequest, null);
 
-        // Then
         assertNotNull(response);
         assertEquals("Publicación actualizada con éxito", response.getMessage());
         verify(postRepository).findById(1L);
@@ -529,127 +769,414 @@ class PostServiceImplTest {
         verify(postRepository).save(testPost);
     }
 
+    // Post tiene media=null → se inicializa como lista vacía antes de procesar
     @Test
-    void updatePost_NotFound_ThrowsException() {
-        // Given
-        UpdatePostRequest updateRequest = new UpdatePostRequest();
-        updateRequest.setTitle("Updated Title");
-        updateRequest.setAuthorId(1L);
-        updateRequest.setLatitude(-34.6118);
-        updateRequest.setLongitude(-58.3960);
-        updateRequest.setAddress("Updated Address");
+    void updatePost_MediaNullEnPost_InicializaListaVaciaYProcede() {
+        testPost.setMedia(null);
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(null);
 
-        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(postRepository.save(testPost)).thenReturn(testPost);
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.updatePost(1L, updateRequest, null)
-        );
+        ApiResponse response = postService.updatePost(1L, updateRequest, null);
 
-        assertEquals("Publicación no encontrada con id: 1", exception.getMessage());
+        assertNotNull(response);
+        assertEquals("Publicación actualizada con éxito", response.getMessage());
+        assertNotNull(testPost.getMedia());
     }
 
+    // Post tiene una imagen que no está en keepImageIds → se elimina de Cloudinary y de BD
     @Test
-    void deletePost_Success() {
-        // Given - deletePost hace eliminación LÓGICA, no física
-        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
-        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+    void updatePost_EliminaImagenNoEnKeepIds_LlamaBorradoCloudinary() throws Exception {
+        Media mediaExistente = new Media();
+        mediaExistente.setId(10L);
+        mediaExistente.setCloudinaryId("cloudinary_existing_id");
+        mediaExistente.setUrl("http://example.com/old.jpg");
+        mediaExistente.setType(MediaType.IMAGE);
 
-        // When
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(mediaExistente)));
+
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(Collections.emptyList()); // no se conserva ninguna
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(cloudinaryService.delete("cloudinary_existing_id")).thenReturn(new HashMap<>());
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        ApiResponse response = postService.updatePost(1L, updateRequest, null);
+
+        assertNotNull(response);
+        verify(cloudinaryService).delete("cloudinary_existing_id");
+        assertTrue(testPost.getMedia().isEmpty());
+    }
+
+    // Imagen a eliminar con cloudinaryId en blanco → NO se llama a cloudinaryService.delete
+    @Test
+    void updatePost_ImagenAEliminarConCloudinaryIdBlanco_NoLlamaBorradoCloudinary() throws Exception {
+        Media mediaConIdBlanco = new Media();
+        mediaConIdBlanco.setId(20L);
+        mediaConIdBlanco.setCloudinaryId("   ");
+        mediaConIdBlanco.setUrl("http://example.com/blank.jpg");
+        mediaConIdBlanco.setType(MediaType.IMAGE);
+
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(mediaConIdBlanco)));
+
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(Collections.emptyList());
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        postService.updatePost(1L, updateRequest, null);
+
+        verify(cloudinaryService, never()).delete(any());
+    }
+
+    // Cloudinary lanza excepción al eliminar → se captura y el proceso continúa
+    @Test
+    void updatePost_CloudinaryDeleteFalla_ContinuaProceso() throws Exception {
+        Media mediaExistente = new Media();
+        mediaExistente.setId(10L);
+        mediaExistente.setCloudinaryId("cloudinary_id_to_fail");
+        mediaExistente.setUrl("http://example.com/fail.jpg");
+        mediaExistente.setType(MediaType.IMAGE);
+
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(mediaExistente)));
+
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(Collections.emptyList());
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(cloudinaryService.delete("cloudinary_id_to_fail"))
+                .thenThrow(new RuntimeException("Error de conexión Cloudinary"));
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        // No debe lanzar excepción; el error de Cloudinary se absorbe
+        ApiResponse response = postService.updatePost(1L, updateRequest, null);
+
+        assertNotNull(response);
+        assertEquals("Publicación actualizada con éxito", response.getMessage());
+    }
+
+    // keepImageIds vacío + 1 imagen nueva (total = 1 <= 5) → se sube exitosamente
+    @Test
+    void updatePost_ConNuevaImagenYLimiteNoSuperado_SubeACloudinary() throws Exception {
+        Map<String, Object> uploadResult = validUploadResultMock();
+
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(Collections.emptyList());
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(cloudinaryService.upload(mockImage)).thenReturn(uploadResult);
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        ApiResponse response = postService.updatePost(1L, updateRequest, Collections.singletonList(mockImage));
+
+        assertNotNull(response);
+        assertEquals("Publicación actualizada con éxito", response.getMessage());
+        verify(cloudinaryService).upload(mockImage);
+    }
+
+    // keepImageIds tiene 4 ids + 2 nuevas imágenes = 6 > 5 → excepción
+    @Test
+    void updatePost_NuevasImagenesSuperanLimite_LanzaIllegalArgumentException() throws Exception {
+        List<Long> keepIds = Arrays.asList(1L, 2L, 3L, 4L);
+
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(keepIds);
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+
+        List<MultipartFile> tooManyImages = Arrays.asList(mockImage, mockImage);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> postService.updatePost(1L, updateRequest, tooManyImages));
+
+        assertEquals("Máximo 5 imágenes permitidas por publicación", ex.getMessage());
+    }
+
+    // Cloudinary falla al subir nueva imagen → se relanza como RuntimeException
+    @Test
+    void updatePost_CloudinaryUploadFallaEnNuevaImagen_LanzaRuntimeException() throws Exception {
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        updateRequest.setKeepImageIds(Collections.emptyList());
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(locationRepository.findLocationsByProximity(-34.6118, -58.3960))
+                .thenReturn(Collections.singletonList(testLocation));
+        when(cloudinaryService.upload(mockImage)).thenThrow(new RuntimeException("Error al subir"));
+
+        List<MultipartFile> images = Collections.singletonList(mockImage);
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> postService.updatePost(1L, updateRequest, images));
+
+        assertTrue(ex.getMessage().contains("Error al subir imagen"));
+    }
+
+    // Post con id=1 no existe → excepción inmediata
+    @Test
+    void updatePost_PostNoEncontrado_LanzaResourceNotFoundException() {
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.updatePost(1L, updateRequest, null));
+
+        assertEquals("Publicación no encontrada con id: 1", ex.getMessage());
+    }
+
+    // Post existe pero el autor del request no existe → excepción
+    @Test
+    void updatePost_AutorNoEncontrado_LanzaResourceNotFoundException() {
+        UpdatePostRequest updateRequest = validUpdateRequestMock();
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.updatePost(1L, updateRequest, null));
+
+        assertEquals("Usuario no encontrado con id: 1", ex.getMessage());
+    }
+
+    // ─── deletePost ───────────────────────────────────────────────────────────
+
+    // Post activo → cambia status a DELETED (eliminación lógica, no física)
+    @Test
+    void deletePost_PostExistente_EliminacionLogicaYRetornaMensajeExito() {
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
         ApiResponse response = postService.deletePost(1L);
 
-        // Then
         assertNotNull(response);
         assertEquals("Publicación eliminada con éxito", response.getMessage());
+        assertEquals(PostStatus.DELETED, testPost.getStatus());
         verify(postRepository).save(testPost);
         verify(postRepository, never()).delete(testPost);
-
-        // Verificar que el status cambió a DELETED
-        assertEquals(PostStatus.DELETED, testPost.getStatus());
     }
 
+    // Post con id=1 no existe → excepción con mensaje exacto
     @Test
-    void deletePost_NotFound_ThrowsException() {
-        // Given
+    void deletePost_PostNoEncontrado_LanzaResourceNotFoundException() {
         when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
-        // When & Then
-        ResourceNotFoundException exception = assertThrows(
-            ResourceNotFoundException.class,
-            () -> postService.deletePost(1L)
-        );
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.deletePost(1L));
 
-        assertEquals("Publicación no encontrada con id: 1", exception.getMessage());
+        assertEquals("Publicación no encontrada con id: 1", ex.getMessage());
     }
 
+    // ─── deletePostMedia ──────────────────────────────────────────────────────
+
+    // Post tiene imagen con cloudinaryId válido → se borra de Cloudinary y luego de BD
     @Test
-    void deletePostMedia_Success() {
-        // Given
-        Media testMedia = new Media();
-        testMedia.setId(1L);
-        testMedia.setCloudinaryId("test123");
+    void deletePostMedia_ImagenConCloudinaryId_EliminaDeCloudinaryYBD() throws Exception {
+        Media media = new Media();
+        media.setId(1L);
+        media.setCloudinaryId("test_cloudinary_123");
+        media.setType(MediaType.IMAGE);
+        media.setUrl("http://example.com/img.jpg");
 
-        testPost.setMedia(new ArrayList<>(Arrays.asList(testMedia)));
-
-        Map<String, Object> deleteResult = new HashMap<>();
-        deleteResult.put("result", "ok");
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(media)));
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
-        when(cloudinaryService.delete("test123")).thenReturn(deleteResult);
-        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+        when(cloudinaryService.delete("test_cloudinary_123")).thenReturn(new HashMap<>());
+        when(postRepository.save(testPost)).thenReturn(testPost);
 
-        // When
         ApiResponse response = postService.deletePostMedia(1L, 1L);
 
-        // Then
         assertNotNull(response);
         assertEquals("Imagen eliminada con éxito", response.getMessage());
-        verify(cloudinaryService).delete("test123");
+        verify(cloudinaryService).delete("test_cloudinary_123");
         verify(postRepository).save(testPost);
+        assertTrue(testPost.getMedia().isEmpty());
     }
 
+    // Media sin cloudinaryId (null) → no se llama a cloudinaryService.delete
     @Test
-    void addPostMedia_Success() {
-        // Given
-        List<String> imageUrls = Arrays.asList("http://test.com/image1.jpg", "http://test.com/image2.jpg");
-        testPost.setMedia(new ArrayList<>());
+    void deletePostMedia_ImagenSinCloudinaryId_NoLlamaCloudinaryDelete() throws Exception {
+        Media media = new Media();
+        media.setId(1L);
+        media.setCloudinaryId(null);
+        media.setType(MediaType.IMAGE);
+        media.setUrl("http://example.com/img.jpg");
+
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(media)));
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
-        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+        when(postRepository.save(testPost)).thenReturn(testPost);
 
-        // When
-        ApiResponse response = postService.addPostMedia(1L, imageUrls);
+        ApiResponse response = postService.deletePostMedia(1L, 1L);
 
-        // Then
+        assertNotNull(response);
+        assertEquals("Imagen eliminada con éxito", response.getMessage());
+        verify(cloudinaryService, never()).delete(any());
+    }
+
+    // Cloudinary lanza excepción al borrar → se captura y se elimina de BD igualmente
+    @Test
+    void deletePostMedia_CloudinaryFallaAlEliminar_ContinuaYEliminaDeDB() throws Exception {
+        Media media = new Media();
+        media.setId(1L);
+        media.setCloudinaryId("cloudinary_fail_id");
+        media.setType(MediaType.IMAGE);
+        media.setUrl("http://example.com/img.jpg");
+
+        testPost.setMedia(new ArrayList<>(Collections.singletonList(media)));
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(cloudinaryService.delete("cloudinary_fail_id"))
+                .thenThrow(new RuntimeException("Error de Cloudinary"));
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        ApiResponse response = postService.deletePostMedia(1L, 1L);
+
+        assertNotNull(response);
+        assertEquals("Imagen eliminada con éxito", response.getMessage());
+        assertTrue(testPost.getMedia().isEmpty());
+    }
+
+    // Post con id=1 no existe → excepción inmediata
+    @Test
+    void deletePostMedia_PostNoEncontrado_LanzaResourceNotFoundException() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.deletePostMedia(1L, 1L));
+
+        assertEquals("Publicación no encontrada con id: 1", ex.getMessage());
+    }
+
+    // Post existe pero no contiene la imagen con id=99 → excepción
+    @Test
+    void deletePostMedia_MediaNoEncontrada_LanzaResourceNotFoundException() {
+        testPost.setMedia(new ArrayList<>());
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.deletePostMedia(1L, 99L));
+
+        assertEquals("Imagen no encontrada con id: 99", ex.getMessage());
+    }
+
+    // ─── addPostMedia ─────────────────────────────────────────────────────────
+
+    // Post ya tiene 2 imágenes; se agregan 2 más (total 4 <= 5) → éxito
+    @Test
+    void addPostMedia_PostConMediaExistente_AgregaNuevosUrls() {
+        Media mediaExistente1 = new Media();
+        mediaExistente1.setId(1L);
+        Media mediaExistente2 = new Media();
+        mediaExistente2.setId(2L);
+        testPost.setMedia(new ArrayList<>(Arrays.asList(mediaExistente1, mediaExistente2)));
+
+        List<String> newUrls = Arrays.asList("http://example.com/new1.jpg", "http://example.com/new2.jpg");
+
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(postRepository.save(testPost)).thenReturn(testPost);
+
+        ApiResponse response = postService.addPostMedia(1L, newUrls);
+
         assertNotNull(response);
         assertEquals("Imágenes agregadas con éxito", response.getMessage());
+        assertEquals(4, testPost.getMedia().size());
         verify(postRepository).save(testPost);
     }
 
+    // Post con getMedia() == null → se inicializa internamente y agrega los urls
     @Test
-    void addPostMedia_ExceedsLimit_ThrowsException() {
-        // Given
-        List<String> imageUrls = Arrays.asList("url1", "url2");
+    void addPostMedia_PostSinMedia_InicializaListaYAgregaUrls() {
+        testPost.setMedia(null);
+        List<String> newUrls = Collections.singletonList("http://example.com/img.jpg");
 
-        // Crear media existente manualmente
-        Media media1 = new Media();
-        Media media2 = new Media();
-        Media media3 = new Media();
-        Media media4 = new Media();
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(postRepository.save(testPost)).thenReturn(testPost);
 
-        List<Media> existingMedia = Arrays.asList(media1, media2, media3, media4); // 4 existentes
-        testPost.setMedia(existingMedia);
+        ApiResponse response = postService.addPostMedia(1L, newUrls);
+
+        assertNotNull(response);
+        assertEquals("Imágenes agregadas con éxito", response.getMessage());
+        assertNotNull(testPost.getMedia());
+        assertEquals(1, testPost.getMedia().size());
+        assertEquals("http://example.com/img.jpg", testPost.getMedia().get(0).getUrl());
+        assertEquals(MediaType.IMAGE, testPost.getMedia().get(0).getType());
+    }
+
+    // 4 imágenes existentes + 2 nuevas = 6 > 5 → excepción antes de guardar
+    @Test
+    void addPostMedia_SuperaLimiteDecinco_LanzaIllegalArgumentException() {
+        Media m1 = new Media(); m1.setId(1L);
+        Media m2 = new Media(); m2.setId(2L);
+        Media m3 = new Media(); m3.setId(3L);
+        Media m4 = new Media(); m4.setId(4L);
+        testPost.setMedia(new ArrayList<>(Arrays.asList(m1, m2, m3, m4)));
+
+        List<String> newUrls = Arrays.asList("http://example.com/img5.jpg", "http://example.com/img6.jpg");
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
 
-        // When & Then
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> postService.addPostMedia(1L, imageUrls)
-        );
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> postService.addPostMedia(1L, newUrls));
 
         assertEquals("No se pueden agregar más imágenes. Límite máximo: 5 imágenes por publicación",
-                     exception.getMessage());
+                ex.getMessage());
+        verify(postRepository, never()).save(any());
+    }
+
+    // Post con id=1 no existe → excepción inmediata
+    @Test
+    void addPostMedia_PostNoEncontrado_LanzaResourceNotFoundException() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        List<String> urls = Collections.singletonList("http://url.com/img.jpg");
+        ResourceNotFoundException ex = assertThrows(
+                ResourceNotFoundException.class,
+                () -> postService.addPostMedia(1L, urls));
+
+        assertEquals("Publicación no encontrada con id: 1", ex.getMessage());
+    }
+
+    // ─── helpers privados de test ─────────────────────────────────────────────
+
+    private UpdatePostRequest validUpdateRequestMock() {
+        UpdatePostRequest req = new UpdatePostRequest();
+        req.setTitle("Titulo Actualizado");
+        req.setContent("Contenido actualizado con suficiente texto");
+        req.setDate(LocalDate.of(2024, 6, 15));
+        req.setCategory(Category.INFORMATION);
+        req.setAuthorId(1L);
+        req.setLatitude(-34.6118);
+        req.setLongitude(-58.3960);
+        req.setAddress("Dirección Actualizada");
+        req.setIsByIA(false);
+        req.setKeepImageIds(new ArrayList<>());
+        return req;
     }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/PostVerificationQueryServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/PostVerificationQueryServiceImplTest.java
@@ -1,0 +1,173 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.model.Post;
+import com.mypresentpast.backend.model.PostVerification;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
+import com.mypresentpast.backend.repository.PostVerificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostVerificationQueryServiceImplTest {
+
+    @Mock
+    private PostVerificationRepository postVerificationRepository;
+
+    @InjectMocks
+    private PostVerificationQueryServiceImpl postVerificationQueryService;
+
+    private User institutionAuthor;
+    private User normalAuthor;
+    private User verifierUser;
+    private Post postByInstitution;
+    private Post postByNormalUser;
+
+    @BeforeEach
+    void setUp() {
+        institutionAuthor = User.builder()
+                .id(10L)
+                .profileUsername("institution_user")
+                .role(UserRole.INSTITUTION)
+                .build();
+
+        normalAuthor = User.builder()
+                .id(20L)
+                .profileUsername("normal_user")
+                .role(UserRole.NORMAL)
+                .build();
+
+        verifierUser = User.builder()
+                .id(30L)
+                .profileUsername("verifier_institution")
+                .role(UserRole.INSTITUTION)
+                .build();
+
+        postByInstitution = Post.builder()
+                .id(1L)
+                .author(institutionAuthor)
+                .build();
+
+        postByNormalUser = Post.builder()
+                .id(2L)
+                .author(normalAuthor)
+                .build();
+    }
+
+    // ── isPostVerified ─────────────────────────────────────────────────────
+
+    // Post cuyo autor tiene rol INSTITUTION se considera auto-verificado; no consulta el repositorio.
+    @Test
+    void isPostVerified_AuthorIsInstitution_ReturnsTrueWithoutQueryingRepository() {
+        boolean result = postVerificationQueryService.isPostVerified(postByInstitution);
+
+        assertTrue(result);
+        verifyNoInteractions(postVerificationRepository);
+    }
+
+    // Post de usuario NORMAL con verificación activa en repositorio debe retornar true.
+    @Test
+    void isPostVerified_AuthorIsNormalAndActiveVerificationExists_ReturnsTrue() {
+        when(postVerificationRepository.existsActiveByPostId(2L)).thenReturn(true);
+
+        boolean result = postVerificationQueryService.isPostVerified(postByNormalUser);
+
+        assertTrue(result);
+        verify(postVerificationRepository).existsActiveByPostId(2L);
+    }
+
+    // Post de usuario NORMAL sin verificación activa debe retornar false.
+    @Test
+    void isPostVerified_AuthorIsNormalAndNoActiveVerification_ReturnsFalse() {
+        when(postVerificationRepository.existsActiveByPostId(2L)).thenReturn(false);
+
+        boolean result = postVerificationQueryService.isPostVerified(postByNormalUser);
+
+        assertFalse(result);
+        verify(postVerificationRepository).existsActiveByPostId(2L);
+    }
+
+    // Post sin autor no activa la regla de auto-verificación; delega al repositorio.
+    @Test
+    void isPostVerified_AuthorIsNull_DelegatesToRepositoryAndReturnsTrue() {
+        Post postWithNullAuthor = Post.builder().id(3L).author(null).build();
+        when(postVerificationRepository.existsActiveByPostId(3L)).thenReturn(true);
+
+        boolean result = postVerificationQueryService.isPostVerified(postWithNullAuthor);
+
+        assertTrue(result);
+        verify(postVerificationRepository).existsActiveByPostId(3L);
+    }
+
+    // ── getActiveVerification ──────────────────────────────────────────────
+
+    // Cuando el repositorio encuentra una verificación activa, retorna Optional con la verificación.
+    @Test
+    void getActiveVerification_ActiveVerificationExists_ReturnsNonEmptyOptional() {
+        PostVerification verification = PostVerification.builder()
+                .id(100L)
+                .post(postByNormalUser)
+                .verifiedBy(verifierUser)
+                .verifiedAt(LocalDateTime.of(2025, 1, 15, 10, 0))
+                .build();
+        when(postVerificationRepository.findActiveByPostId(2L)).thenReturn(Optional.of(verification));
+
+        Optional<PostVerification> result = postVerificationQueryService.getActiveVerification(2L);
+
+        assertTrue(result.isPresent());
+        assertEquals(100L, result.get().getId());
+        assertEquals(verifierUser, result.get().getVerifiedBy());
+        verify(postVerificationRepository).findActiveByPostId(2L);
+    }
+
+    // Cuando el repositorio no encuentra verificación activa, retorna Optional vacío.
+    @Test
+    void getActiveVerification_NoActiveVerification_ReturnsEmptyOptional() {
+        when(postVerificationRepository.findActiveByPostId(2L)).thenReturn(Optional.empty());
+
+        Optional<PostVerification> result = postVerificationQueryService.getActiveVerification(2L);
+
+        assertFalse(result.isPresent());
+        verify(postVerificationRepository).findActiveByPostId(2L);
+    }
+
+    // ── getExternalVerifier ────────────────────────────────────────────────
+
+    // Cuando existe verificación activa, retorna el usuario que verificó el post.
+    @Test
+    void getExternalVerifier_ActiveVerificationExists_ReturnsVerifiedByUser() {
+        PostVerification verification = PostVerification.builder()
+                .id(100L)
+                .post(postByNormalUser)
+                .verifiedBy(verifierUser)
+                .verifiedAt(LocalDateTime.of(2025, 1, 15, 10, 0))
+                .build();
+        when(postVerificationRepository.findActiveByPostId(2L)).thenReturn(Optional.of(verification));
+
+        User result = postVerificationQueryService.getExternalVerifier(2L);
+
+        assertNotNull(result);
+        assertEquals(30L, result.getId());
+        assertEquals("verifier_institution", result.getProfileUsername());
+    }
+
+    // Cuando no existe verificación activa, retorna null indicando que no hay verificador externo.
+    @Test
+    void getExternalVerifier_NoActiveVerification_ReturnsNull() {
+        when(postVerificationRepository.findActiveByPostId(2L)).thenReturn(Optional.empty());
+
+        User result = postVerificationQueryService.getExternalVerifier(2L);
+
+        assertNull(result);
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/PostVerificationServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/PostVerificationServiceImplTest.java
@@ -1,0 +1,251 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.response.ApiResponse;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.exception.UnauthorizedException;
+import com.mypresentpast.backend.model.Post;
+import com.mypresentpast.backend.model.PostVerification;
+import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.UserRole;
+import com.mypresentpast.backend.repository.PostRepository;
+import com.mypresentpast.backend.repository.PostVerificationRepository;
+import com.mypresentpast.backend.utils.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostVerificationServiceImplTest {
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private PostVerificationRepository postVerificationRepository;
+
+    @InjectMocks
+    private PostVerificationServiceImpl postVerificationService;
+
+    private User institutionUser;
+    private User normalUser;
+    private User postAuthor;
+    private Post testPost;
+    private PostVerification activeVerification;
+
+    @BeforeEach
+    void setUp() {
+        institutionUser = User.builder()
+                .id(1L)
+                .email("institution@example.com")
+                .profileUsername("institution_org")
+                .role(UserRole.INSTITUTION)
+                .build();
+
+        normalUser = User.builder()
+                .id(2L)
+                .email("normal@example.com")
+                .profileUsername("normal_user")
+                .role(UserRole.NORMAL)
+                .build();
+
+        postAuthor = User.builder()
+                .id(99L)
+                .email("author@example.com")
+                .profileUsername("post_author")
+                .role(UserRole.NORMAL)
+                .build();
+
+        testPost = Post.builder()
+                .id(10L)
+                .author(postAuthor)
+                .build();
+
+        activeVerification = PostVerification.builder()
+                .id(100L)
+                .post(testPost)
+                .verifiedBy(institutionUser)
+                .verifiedAt(LocalDateTime.of(2025, 1, 15, 10, 0))
+                .build();
+    }
+
+    // ── verifyPost ─────────────────────────────────────────────────────────
+
+    // Una institución verifica exitosamente el post de otro usuario y recibe el mensaje de éxito.
+    @Test
+    void verifyPost_InstitutionUserVerifiesAnotherUserPost_ReturnsSuccessMessage() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postRepository.findByIdWithRelations(10L)).thenReturn(Optional.of(testPost));
+            when(postVerificationRepository.existsActiveByPostId(10L)).thenReturn(false);
+            when(postVerificationRepository.save(any())).thenReturn(activeVerification);
+
+            ApiResponse response = postVerificationService.verifyPost(10L);
+
+            assertEquals("Post verificado exitosamente", response.getMessage());
+        }
+    }
+
+    // La verificación guardada debe tener el post correcto, el usuario verificador, isActive=true y verifiedAt reciente.
+    @Test
+    void verifyPost_InstitutionUserVerifiesPost_PersistsVerificationWithCorrectFields() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postRepository.findByIdWithRelations(10L)).thenReturn(Optional.of(testPost));
+            when(postVerificationRepository.existsActiveByPostId(10L)).thenReturn(false);
+            when(postVerificationRepository.save(any())).thenReturn(activeVerification);
+
+            postVerificationService.verifyPost(10L);
+
+            ArgumentCaptor<PostVerification> captor = ArgumentCaptor.forClass(PostVerification.class);
+            verify(postVerificationRepository).save(captor.capture());
+            PostVerification saved = captor.getValue();
+
+            assertEquals(testPost, saved.getPost());
+            assertEquals(institutionUser, saved.getVerifiedBy());
+            assertTrue(saved.getIsActive());
+            assertTrue(saved.getVerifiedAt().isAfter(LocalDateTime.now().minusSeconds(5)));
+        }
+    }
+
+    // Un usuario con rol NORMAL no puede verificar posts; se lanza UnauthorizedException antes de consultar repos.
+    @Test
+    void verifyPost_NormalUserAttempts_ThrowsUnauthorizedException() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(normalUser);
+
+            assertThrows(UnauthorizedException.class, () -> postVerificationService.verifyPost(10L));
+
+            verifyNoInteractions(postRepository);
+            verifyNoInteractions(postVerificationRepository);
+        }
+    }
+
+    // Un usuario con rol ADMIN no puede verificar posts; se lanza UnauthorizedException.
+    @Test
+    void verifyPost_AdminUserAttempts_ThrowsUnauthorizedException() {
+        User adminUser = User.builder().id(3L).email("admin@example.com").role(UserRole.ADMIN).build();
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(adminUser);
+
+            assertThrows(UnauthorizedException.class, () -> postVerificationService.verifyPost(10L));
+        }
+    }
+
+    // Si el post no existe en el repositorio se lanza ResourceNotFoundException.
+    @Test
+    void verifyPost_PostNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postRepository.findByIdWithRelations(10L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> postVerificationService.verifyPost(10L));
+        }
+    }
+
+    // Una institución no puede verificar sus propios posts; se lanza BadRequestException.
+    @Test
+    void verifyPost_InstitutionVerifiesOwnPost_ThrowsBadRequestException() {
+        Post ownPost = Post.builder().id(10L).author(institutionUser).build();
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postRepository.findByIdWithRelations(10L)).thenReturn(Optional.of(ownPost));
+
+            assertThrows(BadRequestException.class, () -> postVerificationService.verifyPost(10L));
+
+            verifyNoInteractions(postVerificationRepository);
+        }
+    }
+
+    // Si el post ya tiene una verificación activa se lanza BadRequestException.
+    @Test
+    void verifyPost_PostAlreadyVerified_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postRepository.findByIdWithRelations(10L)).thenReturn(Optional.of(testPost));
+            when(postVerificationRepository.existsActiveByPostId(10L)).thenReturn(true);
+
+            assertThrows(BadRequestException.class, () -> postVerificationService.verifyPost(10L));
+
+            verify(postVerificationRepository, never()).save(any());
+        }
+    }
+
+    // ── unverifyPost ───────────────────────────────────────────────────────
+
+    // Una institución desverifica el post que ella misma verificó y recibe el mensaje de éxito.
+    @Test
+    void unverifyPost_InstitutionUserUnverifiesOwnVerification_ReturnsSuccessMessage() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postVerificationRepository.findActiveByPostIdAndVerifiedBy(10L, 1L))
+                    .thenReturn(Optional.of(activeVerification));
+
+            ApiResponse response = postVerificationService.unverifyPost(10L);
+
+            assertEquals("Verificación removida exitosamente", response.getMessage());
+        }
+    }
+
+    // Al desverificar, el campo isActive de la verificación debe quedar en false y guardarse.
+    @Test
+    void unverifyPost_InstitutionUserUnverifiesPost_SetsIsActiveFalseAndSaves() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postVerificationRepository.findActiveByPostIdAndVerifiedBy(10L, 1L))
+                    .thenReturn(Optional.of(activeVerification));
+
+            postVerificationService.unverifyPost(10L);
+
+            assertFalse(activeVerification.getIsActive());
+            verify(postVerificationRepository).save(activeVerification);
+        }
+    }
+
+    // Un usuario con rol NORMAL no puede desverificar posts; se lanza UnauthorizedException.
+    @Test
+    void unverifyPost_NormalUserAttempts_ThrowsUnauthorizedException() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(normalUser);
+
+            assertThrows(UnauthorizedException.class, () -> postVerificationService.unverifyPost(10L));
+
+            verifyNoInteractions(postVerificationRepository);
+        }
+    }
+
+    // Un usuario con rol ADMIN no puede desverificar posts; se lanza UnauthorizedException.
+    @Test
+    void unverifyPost_AdminUserAttempts_ThrowsUnauthorizedException() {
+        User adminUser = User.builder().id(3L).email("admin@example.com").role(UserRole.ADMIN).build();
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(adminUser);
+
+            assertThrows(UnauthorizedException.class, () -> postVerificationService.unverifyPost(10L));
+        }
+    }
+
+    // Si la institución actual no verificó el post, se lanza BadRequestException.
+    @Test
+    void unverifyPost_NoActiveVerificationByCurrentInstitution_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUser).thenReturn(institutionUser);
+            when(postVerificationRepository.findActiveByPostIdAndVerifiedBy(10L, 1L))
+                    .thenReturn(Optional.empty());
+
+            assertThrows(BadRequestException.class, () -> postVerificationService.unverifyPost(10L));
+
+            verify(postVerificationRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/ProfileServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/ProfileServiceImplTest.java
@@ -2,31 +2,42 @@ package com.mypresentpast.backend.service.impl;
 
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
+import com.mypresentpast.backend.enums.PostStatus;
+import com.mypresentpast.backend.model.UserRole;
+import com.mypresentpast.backend.exception.BadRequestException;
+import com.mypresentpast.backend.exception.ResourceNotFoundException;
+import com.mypresentpast.backend.exception.UnauthorizedException;
 import com.mypresentpast.backend.model.User;
 import com.mypresentpast.backend.repository.FollowRepository;
 import com.mypresentpast.backend.repository.PostRepository;
 import com.mypresentpast.backend.repository.UserRepository;
 import com.mypresentpast.backend.service.CloudinaryService;
 import com.mypresentpast.backend.service.JwtService;
+import com.mypresentpast.backend.utils.SecurityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class ProfileServiceImplTest {
 
-    @InjectMocks
-    private ProfileServiceImpl systemUnderTest;
+    // ── Mocks ──────────────────────────────────────────────────────────────
     @Mock
     private UserRepository userRepository;
     @Mock
@@ -36,255 +47,330 @@ class ProfileServiceImplTest {
     @Mock
     private PasswordEncoder passwordEncoder;
     @Mock
+    private CloudinaryService cloudinaryService;
+    @Mock
     private JwtService jwtService;
 
+    @InjectMocks
+    private ProfileServiceImpl profileService;
+
+    // ── Datos de test reutilizables ────────────────────────────────────────
+    private User testUser;
+
+    // ── Setup ──────────────────────────────────────────────────────────────
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
-
-
-    @Test
-    void updateProfile_validData_userUpdated() {
-        // Arrange
-        ProfileUpdateRequest request = ProfileUpdateRequest.builder()
-                .email("new@email.com")
-                .profileUsername("newUser")
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .profileUsername("testuser")
                 .name("John")
                 .lastName("Doe")
+                .role(UserRole.NORMAL)
+                .emailVerified(true)
+                .avatar("https://cloudinary.com/avatar.jpg")
+                .password("encodedPassword")
                 .build();
+    }
 
-        User existingUser = User.builder()
-                .id(10L)
-                .email("old@email.com")
-                .profileUsername("oldUser")
-                .name("Old")
-                .lastName("Name")
-                .build();
+    // ── getProfile ─────────────────────────────────────────────────────────
 
-        // Mock SecurityUtils.getCurrentUserId()
-        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> securityUtilsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
-            securityUtilsMock.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId).thenReturn(10L);
+    // Verifica que el usuario autenticado viendo su propio perfil recibe el email y isSelf=true.
+    @Test
+    void getProfile_AuthenticatedUserViewingOwnProfile_ReturnsSelfProfileWithEmail() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(followRepository.countByFolloweeId(1L)).thenReturn(10L);
+            when(followRepository.countByFollowerId(1L)).thenReturn(5L);
+            when(postRepository.countByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(3L);
 
-            when(userRepository.findById(10L)).thenReturn(Optional.of(existingUser));
-            when(userRepository.existsByEmail("new@email.com")).thenReturn(false);
-            when(userRepository.existsByProfileUsername("newUser")).thenReturn(false);
-            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-            when(userRepository.save(userCaptor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+            ProfileResponse response = profileService.getProfile(1L);
 
-            when(jwtService.getToken(userCaptor.capture())).thenReturn("nuevoJwtToken");
-            // Act
-            ProfileUpdateResponse response = systemUnderTest.updateProfile(request);
-
-            // Assert
             assertNotNull(response);
-            assertEquals(10L, response.getId());
-            assertEquals("newUser", response.getProfileUsername());
-            assertEquals("new@email.com", response.getEmail());
-            assertEquals("John", response.getName());
-            assertEquals("Doe", response.getLastName());
-
-            User savedUser = userCaptor.getValue();
-            assertEquals("newUser", savedUser.getProfileUsername());
-            assertEquals("new@email.com", savedUser.getEmail());
-            assertEquals("John", savedUser.getName());
-            assertEquals("Doe", savedUser.getLastName());
+            assertEquals(1L, response.getId());
+            assertEquals("testuser", response.getProfileUsername());
+            assertEquals("test@example.com", response.getEmail()); // email incluido por ser perfil propio
+            assertTrue(response.getIsSelf());
+            assertFalse(response.getFollowing()); // no puede seguirse a sí mismo
+            assertEquals(10L, response.getFollowerCount());
+            assertEquals(5L, response.getFollowingCount());
+            assertEquals(3L, response.getPostCount());
+            verify(followRepository, never()).existsByFollowerIdAndFolloweeId(any(), any());
         }
     }
 
+    // Verifica que un usuario autenticado viendo otro perfil no recibe el email y se consulta isFollowing.
     @Test
-    void changePassword_validData_passwordChanged() {
-        // Arrange
-        Long userId = 40L;
-        com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest request =
-                ChangePasswordRequest.builder()
-                        .currentPassword("oldPass")
-                        .newPassword("NewPassword123")
-                        .confirmPassword("NewPassword123")
-                        .build();
+    void getProfile_AuthenticatedUserViewingOtherProfile_ReturnsProfileWithoutEmail() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(2L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(followRepository.existsByFollowerIdAndFolloweeId(2L, 1L)).thenReturn(true);
+            when(followRepository.countByFolloweeId(1L)).thenReturn(10L);
+            when(followRepository.countByFollowerId(1L)).thenReturn(5L);
+            when(postRepository.countByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(3L);
 
-        User user = User.builder()
-                .id(userId)
-                .password("encodedOldPass")
+            ProfileResponse response = profileService.getProfile(1L);
+
+            assertNotNull(response);
+            assertNull(response.getEmail()); // email no incluido por ser perfil ajeno
+            assertFalse(response.getIsSelf());
+            assertTrue(response.getFollowing());
+            verify(followRepository).existsByFollowerIdAndFolloweeId(2L, 1L);
+        }
+    }
+
+    // Verifica que un usuario no autenticado accede al perfil público sin email y sin check de following.
+    @Test
+    void getProfile_UnauthenticatedUser_ReturnsPublicProfileWithoutEmail() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenThrow(new UnauthorizedException("no auth"));
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(followRepository.countByFolloweeId(1L)).thenReturn(10L);
+            when(followRepository.countByFollowerId(1L)).thenReturn(5L);
+            when(postRepository.countByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(3L);
+
+            ProfileResponse response = profileService.getProfile(1L);
+
+            assertNotNull(response);
+            assertNull(response.getEmail());
+            assertFalse(response.getIsSelf());
+            assertFalse(response.getFollowing());
+            verify(followRepository, never()).existsByFollowerIdAndFolloweeId(any(), any());
+        }
+    }
+
+    // Verifica que un userId inválido (null o <= 0) lanza IllegalArgumentException antes de consultar la DB.
+    @Test
+    void getProfile_InvalidUserId_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> profileService.getProfile(0L));
+        assertThrows(IllegalArgumentException.class, () -> profileService.getProfile(-1L));
+        assertThrows(IllegalArgumentException.class, () -> profileService.getProfile(null));
+        verify(userRepository, never()).findById(any());
+    }
+
+    // Verifica que buscar el perfil de un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void getProfile_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> profileService.getProfile(99L));
+        }
+    }
+
+    // ── updateProfile ──────────────────────────────────────────────────────
+
+    // Verifica que los campos del perfil se actualizan correctamente y se retorna un nuevo JWT.
+    @Test
+    void updateProfile_ValidData_UpdatesFieldsAndReturnsNewToken() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            ProfileUpdateRequest request = ProfileUpdateRequest.builder()
+                    .email("new@example.com")
+                    .profileUsername("newuser")
+                    .name("Jane")
+                    .lastName("Smith")
+                    .build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
+            when(userRepository.existsByProfileUsername("newuser")).thenReturn(false);
+            when(userRepository.save(testUser)).thenReturn(testUser);
+            when(jwtService.getToken(testUser)).thenReturn("new-jwt-token");
+
+            ProfileUpdateResponse response = profileService.updateProfile(request);
+
+            assertNotNull(response);
+            assertEquals(1L, response.getId());
+            assertEquals("newuser", response.getProfileUsername());
+            assertEquals("new@example.com", response.getEmail());
+            assertEquals("new-jwt-token", response.getToken());
+            verify(userRepository).save(testUser);
+        }
+    }
+
+    // Verifica que actualizar el perfil de un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void updateProfile_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(99L);
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            ProfileUpdateRequest request = ProfileUpdateRequest.builder().build();
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileService.updateProfile(request));
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que cambiar a un email ya registrado lanza DataIntegrityViolationException.
+    @Test
+    void updateProfile_DuplicateEmail_ThrowsDataIntegrityViolationException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(userRepository.existsByEmail("taken@example.com")).thenReturn(true);
+
+            ProfileUpdateRequest request = ProfileUpdateRequest.builder().email("taken@example.com").build();
+            assertThrows(DataIntegrityViolationException.class,
+                    () -> profileService.updateProfile(request));
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // Verifica que cambiar a un username ya registrado lanza DataIntegrityViolationException.
+    @Test
+    void updateProfile_DuplicateUsername_ThrowsDataIntegrityViolationException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(userRepository.existsByProfileUsername("takenuser")).thenReturn(true);
+
+            ProfileUpdateRequest request = ProfileUpdateRequest.builder().profileUsername("takenuser").build();
+            assertThrows(DataIntegrityViolationException.class,
+                    () -> profileService.updateProfile(request));
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+
+    // ── changePassword ─────────────────────────────────────────────────────
+
+    // Verifica que la nueva contraseña se codifica y se persiste cuando los datos son válidos.
+    @Test
+    void changePassword_ValidData_EncodesAndSavesNewPassword() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("oldPass")
+                .newPassword("NewPassword123")
+                .confirmPassword("NewPassword123")
                 .build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        try (MockedStatic<com.mypresentpast.backend.utils.CommonFunctions> commonFunctionsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.CommonFunctions.class)) {
-            commonFunctionsMock.when(() -> com.mypresentpast.backend.utils.CommonFunctions.isValidPassword("NewPassword123")).thenReturn(true);
-            when(passwordEncoder.matches("oldPass", "encodedOldPass")).thenReturn(true);
-            when(passwordEncoder.matches("NewPassword123", "encodedOldPass")).thenReturn(false);
-            when(passwordEncoder.encode("NewPassword123")).thenReturn("encodedNewPass");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("oldPass", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.matches("NewPassword123", "encodedPassword")).thenReturn(false);
+        when(passwordEncoder.encode("NewPassword123")).thenReturn("encodedNewPassword");
 
-            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-            when(userRepository.save(userCaptor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+        profileService.changePassword(1L, request);
 
-            // Act
-            systemUnderTest.changePassword(userId, request);
-
-            // Assert
-            User savedUser = userCaptor.getValue();
-            assertEquals("encodedNewPass", savedUser.getPassword());
-        }
+        assertEquals("encodedNewPassword", testUser.getPassword());
+        verify(userRepository).save(testUser);
     }
 
+    // Verifica que confirmar una contraseña distinta lanza BadRequestException sin consultar la DB.
     @Test
-    void changePassword_passwordMismatch_throwsException() {
-        // Arrange
-        Long userId = 50L;
-        com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest request =
-                com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest.builder()
-                        .currentPassword("oldPass")
-                        .newPassword("NewPassword123")
-                        .confirmPassword("DifferentPassword")
-                        .build();
-
-        // Act & Assert
-        org.junit.jupiter.api.Assertions.assertThrows(com.mypresentpast.backend.exception.BadRequestException.class, () -> {
-            systemUnderTest.changePassword(userId, request);
-        });
-    }
-
-    @Test
-    void changePassword_invalidPassword_throwsException() {
-        // Arrange
-        Long userId = 60L;
-        com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest request =
-                com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest.builder()
-                        .currentPassword("oldPass")
-                        .newPassword("bad")
-                        .confirmPassword("bad")
-                        .build();
-
-        try (MockedStatic<com.mypresentpast.backend.utils.CommonFunctions> commonFunctionsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.CommonFunctions.class)) {
-            commonFunctionsMock.when(() -> com.mypresentpast.backend.utils.CommonFunctions.isValidPassword("bad")).thenReturn(false);
-
-            // Act & Assert
-            org.junit.jupiter.api.Assertions.assertThrows(com.mypresentpast.backend.exception.BadRequestException.class, () -> {
-                systemUnderTest.changePassword(userId, request);
-            });
-        }
-    }
-
-    @Test
-    void changePassword_currentPasswordInvalid_throwsException() {
-        // Arrange
-        Long userId = 70L;
-        com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest request =
-                com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest.builder()
-                        .currentPassword("wrongPass")
-                        .newPassword("NewPassword123")
-                        .confirmPassword("NewPassword123")
-                        .build();
-
-        User user = User.builder()
-                .id(userId)
-                .password("encodedOldPass")
+    void changePassword_PasswordMismatch_ThrowsBadRequestException() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("oldPass")
+                .newPassword("NewPassword123")
+                .confirmPassword("DifferentPassword")
                 .build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        try (MockedStatic<com.mypresentpast.backend.utils.CommonFunctions> commonFunctionsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.CommonFunctions.class)) {
-            commonFunctionsMock.when(() -> com.mypresentpast.backend.utils.CommonFunctions.isValidPassword("NewPassword123")).thenReturn(true);
-            when(passwordEncoder.matches("wrongPass", "encodedOldPass")).thenReturn(false);
-
-            // Act & Assert
-            org.junit.jupiter.api.Assertions.assertThrows(com.mypresentpast.backend.exception.BadRequestException.class, () -> {
-                systemUnderTest.changePassword(userId, request);
-            });
-        }
+        assertThrows(BadRequestException.class, () -> profileService.changePassword(1L, request));
+        verify(userRepository, never()).findById(any());
     }
 
+    // Verifica que una contraseña nueva que no cumple los requisitos lanza BadRequestException sin consultar la DB.
     @Test
-    void changePassword_newPasswordSameAsOld_throwsException() {
-        // Arrange
-        Long userId = 80L;
-        com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest request =
-                com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest.builder()
-                        .currentPassword("oldPass")
-                        .newPassword("NewPassword123")
-                        .confirmPassword("NewPassword123")
-                        .build();
-
-        User user = User.builder()
-                .id(userId)
-                .password("encodedOldPass")
+    void changePassword_InvalidNewPassword_ThrowsBadRequestException() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("oldPass")
+                .newPassword("bad")
+                .confirmPassword("bad")
                 .build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        try (MockedStatic<com.mypresentpast.backend.utils.CommonFunctions> commonFunctionsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.CommonFunctions.class)) {
-            commonFunctionsMock.when(() -> com.mypresentpast.backend.utils.CommonFunctions.isValidPassword("NewPassword123")).thenReturn(true);
-            when(passwordEncoder.matches("oldPass", "encodedOldPass")).thenReturn(true);
-            when(passwordEncoder.matches("NewPassword123", "encodedOldPass")).thenReturn(true);
-
-            // Act & Assert
-            org.junit.jupiter.api.Assertions.assertThrows(com.mypresentpast.backend.exception.BadRequestException.class, () -> {
-                systemUnderTest.changePassword(userId, request);
-            });
-        }
+        assertThrows(BadRequestException.class, () -> profileService.changePassword(1L, request));
+        verify(userRepository, never()).findById(any());
     }
 
-
+    // Verifica que cambiar contraseña de un usuario inexistente lanza ResourceNotFoundException.
     @Test
-    void uploadAvatar_validFile_avatarUrlReturnedAndUserUpdated() {
-        // Arrange
-        Long userId = 100L;
-        User user = User.builder()
-                .id(userId)
-                .avatar(null)
+    void changePassword_UserNotFound_ThrowsResourceNotFoundException() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("oldPass")
+                .newPassword("NewPassword123")
+                .confirmPassword("NewPassword123")
                 .build();
 
-        MultipartFile file = Mockito.mock(MultipartFile.class);
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-        Map<String, Object> uploadResult = new HashMap<>();
-        uploadResult.put("secure_url", "https://cloudinary.com/avatar.jpg");
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileService.changePassword(1L, request));
 
-        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> securityUtilsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
-            securityUtilsMock.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId).thenReturn(userId);
+        verify(userRepository, never()).save(any());
+    }
 
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    // Verifica que una contraseña actual incorrecta lanza BadRequestException.
+    @Test
+    void changePassword_CurrentPasswordInvalid_ThrowsBadRequestException() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("wrongPass")
+                .newPassword("NewPassword123")
+                .confirmPassword("NewPassword123")
+                .build();
 
-            // Mock CloudinaryService
-            CloudinaryService cloudinaryService = Mockito.mock(CloudinaryService.class);
-            // Reemplaza el cloudinaryService en el systemUnderTest si es necesario
-            // Puedes usar ReflectionTestUtils si no tienes setter
-            java.lang.reflect.Field field = systemUnderTest.getClass().getDeclaredField("cloudinaryService");
-            field.setAccessible(true);
-            field.set(systemUnderTest, cloudinaryService);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("wrongPass", "encodedPassword")).thenReturn(false);
 
-            when(cloudinaryService.uploadAvatar(file, userId)).thenReturn(uploadResult);
+        assertThrows(BadRequestException.class, () -> profileService.changePassword(1L, request));
+        verify(userRepository, never()).save(any());
+    }
 
-            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-            when(userRepository.save(userCaptor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+    // Verifica que usar la misma contraseña actual como nueva lanza BadRequestException.
+    @Test
+    void changePassword_NewPasswordSameAsOld_ThrowsBadRequestException() {
+        ChangePasswordRequest request = ChangePasswordRequest.builder()
+                .currentPassword("oldPass")
+                .newPassword("NewPassword123")
+                .confirmPassword("NewPassword123")
+                .build();
 
-            // Act
-            String resultUrl = systemUnderTest.uploadAvatar(file);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("oldPass", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.matches("NewPassword123", "encodedPassword")).thenReturn(true);
 
-            // Assert
-            assertEquals("https://cloudinary.com/avatar.jpg", resultUrl);
-            User savedUser = userCaptor.getValue();
-            assertEquals("https://cloudinary.com/avatar.jpg", savedUser.getAvatar());
+        assertThrows(BadRequestException.class, () -> profileService.changePassword(1L, request));
+        verify(userRepository, never()).save(any());
+    }
 
-            verify(cloudinaryService).uploadAvatar(file, userId);
-            verify(userRepository).save(userCaptor.getValue());
-        } catch (Exception e) {
-            fail("Exception thrown: " + e.getMessage());
+    // ── uploadAvatar ───────────────────────────────────────────────────────
+
+    // Verifica que el avatar se sube a Cloudinary y la URL resultante se persiste en el usuario.
+    @Test
+    void uploadAvatar_ValidFile_UpdatesAvatarUrlAndReturnsIt() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            MultipartFile file = mock(MultipartFile.class);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(cloudinaryService.uploadAvatar(file, 1L))
+                    .thenReturn(Map.of("secure_url", "https://cloudinary.com/new-avatar.jpg"));
+
+            String resultUrl = profileService.uploadAvatar(file);
+
+            assertEquals("https://cloudinary.com/new-avatar.jpg", resultUrl);
+            assertEquals("https://cloudinary.com/new-avatar.jpg", testUser.getAvatar());
+            verify(cloudinaryService).uploadAvatar(file, 1L);
+            verify(userRepository).save(testUser);
         }
     }
 
+    // Verifica que subir avatar para un usuario inexistente lanza ResourceNotFoundException.
     @Test
-    void uploadAvatar_userNotFound_throwsException() {
-        // Arrange
-        Long userId = 200L;
-        MultipartFile file = Mockito.mock(MultipartFile.class);
+    void uploadAvatar_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-        try (MockedStatic<com.mypresentpast.backend.utils.SecurityUtils> securityUtilsMock = Mockito.mockStatic(com.mypresentpast.backend.utils.SecurityUtils.class)) {
-            securityUtilsMock.when(com.mypresentpast.backend.utils.SecurityUtils::getCurrentUserId).thenReturn(userId);
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileService.uploadAvatar(mock(MultipartFile.class)));
 
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-            // Act & Assert
-            assertThrows(com.mypresentpast.backend.exception.ResourceNotFoundException.class, () -> {
-                systemUnderTest.uploadAvatar(file);
-            });
+            verify(cloudinaryService, never()).uploadAvatar(any(), any());
         }
     }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/ReportServiceImplTest.java
@@ -10,15 +10,21 @@ import com.mypresentpast.backend.exception.ResourceNotFoundException;
 import com.mypresentpast.backend.model.Post;
 import com.mypresentpast.backend.model.Report;
 import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.repository.PostRepository;
 import com.mypresentpast.backend.repository.ReportRepository;
 import com.mypresentpast.backend.repository.UserRepository;
 import com.mypresentpast.backend.service.PostService;
+import com.mypresentpast.backend.utils.SecurityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.*;
+
+import java.util.EnumSet;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,6 +35,8 @@ import static org.mockito.Mockito.*;
 
 class ReportServiceImplTest {
 
+    @Mock
+    private PostRepository postRepository;
     @Mock
     private ReportRepository reportRepository;
     @Mock
@@ -43,6 +51,7 @@ class ReportServiceImplTest {
     private Post testPost;
     private User testUser;
     private User adminUser;
+    private User reporterUser;
 
     @BeforeEach
     void setUp() {
@@ -56,6 +65,10 @@ class ReportServiceImplTest {
 
         adminUser = new User();
         adminUser.setId(99L);
+
+        reporterUser = new User();
+        reporterUser.setId(3L);
+        reporterUser.setProfileUsername("reporter2");
 
         testPost = new Post();
         testPost.setId(2L);
@@ -115,9 +128,9 @@ class ReportServiceImplTest {
         assertThrows(RuntimeException.class, () -> reportService.getReportDetail(99L));
     }
 
+    // Simular el comportamiento del repositorio y servicio
     @Test
     void acceptReport_Success() {
-        // Simular el comportamiento del repositorio y servicio
         when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
         when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
         when(reportRepository.save(any(Report.class))).thenReturn(testReport);
@@ -133,26 +146,26 @@ class ReportServiceImplTest {
         verify(postService).deletePost(anyLong());
     }
 
+    // Simular que el reporte no existe
     @Test
     void acceptReport_ReportNotFound_ThrowsException() {
-        // Simular que el reporte no existe
         when(reportRepository.findById(10L)).thenReturn(Optional.empty());
         // Asegurarse de que se lance la excepción ResourceNotFoundException
         assertThrows(ResourceNotFoundException.class, () -> reportService.acceptReport(10L, 99L));
     }
 
+    // Cambiar el estado del reporte a REJECTED para simular un estado inválido
     @Test
     void acceptReport_InvalidStatus_ThrowsException() {
-        // Cambiar el estado del reporte a REJECTED para simular un estado inválido
         testReport.setStatus(ReportStatus.REJECTED);
         when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
         // Asegurarse de que se lance la excepción BadRequestException
         assertThrows(BadRequestException.class, () -> reportService.acceptReport(10L, 99L));
     }
 
+    // Simular el comportamiento del repositorio y servicio
     @Test
     void rejectReport_Success() {
-        // Simular el comportamiento del repositorio y servicio
         when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
         when(userRepository.findById(99L)).thenReturn(Optional.of(adminUser));
         when(reportRepository.save(any(Report.class))).thenReturn(testReport);
@@ -166,20 +179,118 @@ class ReportServiceImplTest {
         assertEquals(ReportStatus.REJECTED, testReport.getStatus());
     }
 
+    // Simular que el reporte no existe
     @Test
     void rejectReport_ReportNotFound_ThrowsException() {
-        // Simular que el reporte no existe
         when(reportRepository.findById(10L)).thenReturn(Optional.empty());
         // asegurarse de que se lance la excepción ResourceNotFoundException
         assertThrows(ResourceNotFoundException.class, () -> reportService.rejectReport(10L, 99L));
     }
 
+    // Cambiar el estado del reporte a ACCEPTED para simular un estado inválido
     @Test
     void rejectReport_InvalidStatus_ThrowsException() {
-        // Cambiar el estado del reporte a ACCEPTED para simular un estado inválido
         testReport.setStatus(ReportStatus.ACCEPTED);
         when(reportRepository.findById(10L)).thenReturn(Optional.of(testReport));
         // asegurarse de que se lance la excepción BadRequestException
         assertThrows(BadRequestException.class, () -> reportService.rejectReport(10L, 99L));
+    }
+
+    // Verifica que al crear un reporte con datos válidos se retorna el mensaje de éxito y se persiste el reporte.
+    @Test
+    void createReport_ValidRequest_ReturnsSuccessMessage() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(3L);
+
+            when(userRepository.findById(3L)).thenReturn(Optional.of(reporterUser));
+            when(postRepository.findById(2L)).thenReturn(Optional.of(testPost));
+            when(reportRepository.existsActiveReportByPostIdAndReporterId(
+                    2L, 3L, EnumSet.of(ReportStatus.PENDING, ReportStatus.ACCEPTED)))
+                    .thenReturn(false);
+
+            ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+            when(reportRepository.save(reportCaptor.capture())).thenReturn(testReport);
+
+            ApiResponse response = reportService.createReport(2L, "Motivo de prueba", ReportType.SPAM);
+
+            assertNotNull(response);
+            assertTrue(response.getMessage().contains("Exito"));
+
+            Report saved = reportCaptor.getValue();
+            assertEquals(testPost, saved.getPost());
+            assertEquals(reporterUser, saved.getReporter());
+            assertEquals("Motivo de prueba", saved.getReason());
+            assertEquals(ReportType.SPAM, saved.getType());
+            assertEquals(ReportStatus.PENDING, saved.getStatus());
+
+            verify(reportRepository).save(reportCaptor.getValue());
+        }
+    }
+
+    // Verifica que si el usuario reportero no existe se lanza ResourceNotFoundException.
+    @Test
+    void createReport_ReporterNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(3L);
+
+            when(userRepository.findById(3L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> reportService.createReport(2L, "Motivo", ReportType.SPAM));
+
+            verify(postRepository, never()).findById(any());
+        }
+    }
+
+    // Verifica que si la publicación a reportar no existe se lanza ResourceNotFoundException.
+    @Test
+    void createReport_PostNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(3L);
+
+            when(userRepository.findById(3L)).thenReturn(Optional.of(reporterUser));
+            when(postRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> reportService.createReport(99L, "Motivo", ReportType.SPAM));
+
+            verify(reportRepository, never()).existsActiveReportByPostIdAndReporterId(any(), any(), any());
+        }
+    }
+
+    // Verifica que un usuario no puede reportar su propia publicación.
+    @Test
+    void createReport_SelfReport_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            // testUser (id=1) es el autor de testPost
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(postRepository.findById(2L)).thenReturn(Optional.of(testPost));
+
+            assertThrows(BadRequestException.class,
+                    () -> reportService.createReport(2L, "Motivo", ReportType.SPAM));
+
+            verify(reportRepository, never()).existsActiveReportByPostIdAndReporterId(any(), any(), any());
+        }
+    }
+
+    // Verifica que no se puede crear un reporte si ya existe uno activo del mismo usuario para la misma publicación.
+    @Test
+    void createReport_ActiveReportAlreadyExists_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(3L);
+
+            when(userRepository.findById(3L)).thenReturn(Optional.of(reporterUser));
+            when(postRepository.findById(2L)).thenReturn(Optional.of(testPost));
+            when(reportRepository.existsActiveReportByPostIdAndReporterId(
+                    2L, 3L, EnumSet.of(ReportStatus.PENDING, ReportStatus.ACCEPTED)))
+                    .thenReturn(true);
+
+            assertThrows(BadRequestException.class,
+                    () -> reportService.createReport(2L, "Motivo", ReportType.SPAM));
+
+            verify(reportRepository, never()).save(any());
+        }
     }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/VerificationServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/VerificationServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.mypresentpast.backend.service.impl;
 
+import com.mypresentpast.backend.dto.request.EmailRequest;
 import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.exception.BadRequestException;
 import com.mypresentpast.backend.exception.ResourceNotFoundException;
@@ -7,7 +8,9 @@ import com.mypresentpast.backend.model.User;
 import com.mypresentpast.backend.model.VerificationToken;
 import com.mypresentpast.backend.repository.UserRepository;
 import com.mypresentpast.backend.repository.VerificationTokenRepository;
+import com.mypresentpast.backend.service.EmailService;
 import com.mypresentpast.backend.utils.MessageBundle;
+import jakarta.mail.MessagingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +23,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,22 +35,33 @@ class VerificationServiceImplTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private EmailService emailService;
+
     @InjectMocks
     private VerificationServiceImpl verificationService;
 
     private User user;
+    private VerificationToken testToken;
 
     @BeforeEach
     void setUp() {
         user = new User();
         user.setId(123L);
         user.setEmail("test@example.com");
+        user.setName("John");
+        user.setLastName("Doe");
         user.setEmailVerified(false);
+
+        testToken = new VerificationToken();
+        testToken.setToken("test-token-123");
+        testToken.setUser(user);
+        testToken.setExpiryDate(LocalDateTime.now().plusHours(24));
     }
 
+    // Verifica que al crear un token se elimina el anterior y se persiste uno nuevo con expiración de 24h.
     @Test
-    void testCreateVerificationToken_whenExistingToken_thenDeletesOldAndCreatesNew() {
-        // Arrange
+    void createVerificationToken_ExistingToken_DeletesOldAndCreatesNew() {
         VerificationToken savedToken = new VerificationToken();
         savedToken.setId(999L);
         savedToken.setUser(user);
@@ -55,87 +69,123 @@ class VerificationServiceImplTest {
         ArgumentCaptor<VerificationToken> captor = ArgumentCaptor.forClass(VerificationToken.class);
         when(tokenRepository.save(captor.capture())).thenReturn(savedToken);
 
-        // Act
         VerificationToken result = verificationService.createVerificationToken(user);
 
-        // Assert
-        verify(tokenRepository, times(1)).deleteByUser(user);
-        verify(tokenRepository, times(1)).save(any(VerificationToken.class));
+        verify(tokenRepository).deleteByUser(refEq(user));
 
-        VerificationToken tokenArg = captor.getValue();
-        assertEquals(user, tokenArg.getUser());
-        assertNotNull(tokenArg.getToken());
-
-        LocalDateTime expiry = tokenArg.getExpiryDate();
-        LocalDateTime now = LocalDateTime.now();
-        assertTrue(expiry.isAfter(now.plusHours(23)));
-        assertTrue(expiry.isBefore(now.plusHours(25)));
-
+        VerificationToken saved = captor.getValue();
+        assertEquals(user, saved.getUser());
+        assertNotNull(saved.getToken());
+        assertTrue(saved.getExpiryDate().isAfter(LocalDateTime.now().plusHours(23)));
+        assertTrue(saved.getExpiryDate().isBefore(LocalDateTime.now().plusHours(25)));
         assertSame(savedToken, result);
     }
 
+    // Verifica que un token inexistente lanza ResourceNotFoundException con el mensaje correcto.
     @Test
-    void testValidateVerificationToken_tokenNotFound_throwsResourceNotFoundException() {
-        // Arrange
-        String fakeToken = "non-existent-token";
-        when(tokenRepository.findByToken(fakeToken)).thenReturn(Optional.empty());
+    void validateVerificationToken_TokenNotFound_ThrowsResourceNotFoundException() {
+        when(tokenRepository.findByToken("non-existent-token")).thenReturn(Optional.empty());
 
-        // Act & Assert
-        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class, () -> {
-            verificationService.validateVerificationToken(fakeToken);
-        });
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,
+                () -> verificationService.validateVerificationToken("non-existent-token"));
 
         assertEquals(MessageBundle.TOKEN_NOT_FOUND, ex.getMessage());
         verify(userRepository, never()).save(any());
         verify(tokenRepository, never()).delete(any());
     }
 
+    // Verifica que un token vencido lanza BadRequestException con el mensaje correcto.
     @Test
-    void testValidateVerificationToken_tokenExpired_throwsBadRequestException() {
-        // Arrange
-        String tokenString = "expired-token";
-        VerificationToken vToken = new VerificationToken();
-        vToken.setToken(tokenString);
-        vToken.setUser(user);
-        vToken.setExpiryDate(LocalDateTime.now().minusHours(1)); // Token vencido
+    void validateVerificationToken_TokenExpired_ThrowsBadRequestException() {
+        testToken.setExpiryDate(LocalDateTime.now().minusHours(1));
+        when(tokenRepository.findByToken("test-token-123")).thenReturn(Optional.of(testToken));
 
-        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.of(vToken));
-
-        // Act & Assert
-        BadRequestException ex = assertThrows(BadRequestException.class, () -> {
-            verificationService.validateVerificationToken(tokenString);
-        });
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> verificationService.validateVerificationToken("test-token-123"));
 
         assertEquals(MessageBundle.TOKEN_EXPIRED, ex.getMessage());
         verify(userRepository, never()).save(any());
         verify(tokenRepository, never()).delete(any());
     }
 
+    // Verifica que un token válido marca el email como verificado, elimina el token y retorna el mensaje correcto.
     @Test
-    void testValidateVerificationToken_validToken_setsEmailVerifiedAndDeletesToken() {
-        // Arrange
-        String validToken = "valid-token-123";
-        VerificationToken vToken = new VerificationToken();
-        vToken.setToken(validToken);
-        vToken.setUser(user);
-        vToken.setExpiryDate(LocalDateTime.now().plusHours(2)); // Token válido
+    void validateVerificationToken_ValidToken_SetsEmailVerifiedAndDeletesToken() {
+        when(tokenRepository.findByToken("test-token-123")).thenReturn(Optional.of(testToken));
 
-        when(tokenRepository.findByToken(validToken)).thenReturn(Optional.of(vToken));
-        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        ApiResponse response = verificationService.validateVerificationToken("test-token-123");
 
-        // Act
-        ApiResponse response = verificationService.validateVerificationToken(validToken);
-
-        // Assert
-        verify(userRepository).save(userCaptor.capture());
-        User savedUser = userCaptor.getValue();
-        assertTrue(savedUser.isEmailVerified());
-
-        verify(tokenRepository).delete(vToken);
-
+        assertTrue(user.isEmailVerified());
+        verify(userRepository).save(user);
+        verify(tokenRepository).delete(testToken);
         assertNotNull(response);
         assertEquals("Email confirmado con éxito", response.getMessage());
     }
 
+    // ── resendVerification ─────────────────────────────────────────────────
 
+    // Verifica que el email de verificación se reenvía con los datos correctos cuando todo es válido.
+    @Test
+    void resendVerification_ValidRequest_SendsEmailWithCorrectData() throws MessagingException {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(tokenRepository.findByUser(user)).thenReturn(Optional.of(testToken));
+
+        EmailRequest expectedEmailRequest = new EmailRequest();
+        expectedEmailRequest.setRecipient("test@example.com");
+        expectedEmailRequest.setSubject("Reenvío: Confirma tu email en MyPresentPast");
+        expectedEmailRequest.setName("John Doe");
+        expectedEmailRequest.setVerificationUrl("http://localhost:4200/verify-success?token=test-token-123");
+
+        verificationService.resendVerification("test@example.com");
+
+        verify(emailService).sendMail(refEq(expectedEmailRequest));
+    }
+
+    // Verifica que buscar un email inexistente lanza ResourceNotFoundException.
+    @Test
+    void resendVerification_UserNotFound_ThrowsResourceNotFoundException() throws MessagingException {
+        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> verificationService.resendVerification("unknown@example.com"));
+
+        verify(emailService, never()).sendMail(any());
+    }
+
+    // Verifica que intentar reenviar el email a un usuario ya verificado lanza BadRequestException.
+    @Test
+    void resendVerification_EmailAlreadyVerified_ThrowsBadRequestException() throws MessagingException {
+        user.setEmailVerified(true);
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(BadRequestException.class,
+                () -> verificationService.resendVerification("test@example.com"));
+
+        verify(emailService, never()).sendMail(any());
+    }
+
+    // Verifica que si no existe token para el usuario se lanza ResourceNotFoundException.
+    @Test
+    void resendVerification_TokenNotFound_ThrowsResourceNotFoundException() throws MessagingException {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(tokenRepository.findByUser(user)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> verificationService.resendVerification("test@example.com"));
+
+        verify(emailService, never()).sendMail(any());
+    }
+
+    // Verifica que un token expirado lanza BadRequestException sin enviar el email.
+    @Test
+    void resendVerification_TokenExpired_ThrowsBadRequestException() throws MessagingException {
+        testToken.setExpiryDate(LocalDateTime.now().minusHours(1));
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(tokenRepository.findByUser(user)).thenReturn(Optional.of(testToken));
+
+        assertThrows(BadRequestException.class,
+                () -> verificationService.resendVerification("test@example.com"));
+
+        verify(emailService, never()).sendMail(any());
+    }
 }


### PR DESCRIPTION
###   SCRUM-210 — Agregar tests unitarios para aumentar cobertura de código                                                            
 
Se crearon y ampliaron tests unitarios para aumentar la cobertura general del backend. Las clases sin cobertura pasaron a tener tests completos y las existentes fueron reforzadas con nuevos casos.