### PR TITLE
SCRUM-221 agregar verificacion por email al cambiar direccion de correo

### DIFF
--- a/src/main/java/com/mypresentpast/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mypresentpast/backend/config/JwtAuthenticationFilter.java
@@ -47,8 +47,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
         email = jwtService.getUsernameFromToken(token);
 
         if(email != null && Objects.isNull(SecurityContextHolder.getContext().getAuthentication())) {
-
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            UserDetails userDetails;
+            try {
+                userDetails = userDetailsService.loadUserByUsername(email);
+            } catch (org.springframework.security.core.userdetails.UsernameNotFoundException e) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
             if(jwtService.isTokenValid(token, userDetails)) {
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/mypresentpast/backend/controller/ProfileController.java
+++ b/src/main/java/com/mypresentpast/backend/controller/ProfileController.java
@@ -2,11 +2,14 @@ package com.mypresentpast.backend.controller;
 
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.request.profile.EmailChangeRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
 import com.mypresentpast.backend.dto.response.PostResponse;
 import com.mypresentpast.backend.dto.response.UrlResponse;
 import java.util.List;
+import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +61,31 @@ public interface ProfileController {
      */
     @PutMapping(value = "/me/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<UrlResponse> uploadMyAvatar(@RequestPart("avatar") MultipartFile file);
+
+    /**
+     * Inicia el flujo de cambio de email: valida contraseña y envía verificación al nuevo email.
+     *
+     * @param request contiene el nuevo email y la contraseña de confirmación
+     * @return mensaje confirmando el envío del correo de verificación
+     */
+    @PostMapping("/me/email-change")
+    ResponseEntity<ApiResponse> initiateEmailChange(@Valid @RequestBody EmailChangeRequest request) throws MessagingException;
+
+    /**
+     * Cancela un cambio de email pendiente eliminando el token de verificación.
+     *
+     * @return 204 No Content
+     */
+    @DeleteMapping("/me/pending-email")
+    ResponseEntity<Void> cancelEmailChange();
+
+    /**
+     * Reenvía el correo de verificación para un cambio de email pendiente.
+     *
+     * @return mensaje confirmando el reenvío
+     */
+    @PostMapping("/me/email-change/resend")
+    ResponseEntity<ApiResponse> resendEmailChange() throws MessagingException;
 
     /**
      * Obtiene las publicaciones que el usuario autenticado ha likeado.

--- a/src/main/java/com/mypresentpast/backend/controller/impl/ProfileControllerImpl.java
+++ b/src/main/java/com/mypresentpast/backend/controller/impl/ProfileControllerImpl.java
@@ -3,6 +3,8 @@ package com.mypresentpast.backend.controller.impl;
 import com.mypresentpast.backend.controller.ProfileController;
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.request.profile.EmailChangeRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
 import com.mypresentpast.backend.dto.response.PostResponse;
@@ -11,6 +13,7 @@ import java.util.List;
 import com.mypresentpast.backend.service.ProfileService;
 import com.mypresentpast.backend.service.PostService;
 import com.mypresentpast.backend.utils.SecurityUtils;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -49,6 +52,22 @@ public class ProfileControllerImpl implements ProfileController {
     public ResponseEntity<UrlResponse> uploadMyAvatar(@RequestPart("avatar") MultipartFile file) {
         String url = profileService.uploadAvatar(file);
         return ResponseEntity.ok(new UrlResponse(url));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> initiateEmailChange(EmailChangeRequest request) throws MessagingException {
+        return ResponseEntity.ok(profileService.initiateEmailChange(request));
+    }
+
+    @Override
+    public ResponseEntity<Void> cancelEmailChange() {
+        profileService.cancelEmailChange();
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> resendEmailChange() throws MessagingException {
+        return ResponseEntity.ok(profileService.resendEmailChange());
     }
 
     @Override

--- a/src/main/java/com/mypresentpast/backend/dto/request/EmailRequest.java
+++ b/src/main/java/com/mypresentpast/backend/dto/request/EmailRequest.java
@@ -10,5 +10,6 @@ public class EmailRequest {
     private String subject;
     private String name;
     private String verificationUrl;
+    private boolean emailChange;
 
 }

--- a/src/main/java/com/mypresentpast/backend/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/mypresentpast/backend/dto/request/ProfileUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.mypresentpast.backend.dto.request;
 
-import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,8 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProfileUpdateRequest {
     private String profileUsername;
-    @Email
-    private String email;
     private String name;
     private String lastName;
 }

--- a/src/main/java/com/mypresentpast/backend/dto/request/profile/EmailChangeRequest.java
+++ b/src/main/java/com/mypresentpast/backend/dto/request/profile/EmailChangeRequest.java
@@ -1,0 +1,15 @@
+package com.mypresentpast.backend.dto.request.profile;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailChangeRequest {
+    @Email
+    @NotBlank
+    private String newEmail;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/mypresentpast/backend/dto/response/ProfileResponse.java
+++ b/src/main/java/com/mypresentpast/backend/dto/response/ProfileResponse.java
@@ -26,4 +26,5 @@ public class ProfileResponse {
     private Long postCount;
     private Long followerCount;
     private Long followingCount;
+    private String pendingEmail;
 }

--- a/src/main/java/com/mypresentpast/backend/dto/response/ProfileUpdateResponse.java
+++ b/src/main/java/com/mypresentpast/backend/dto/response/ProfileUpdateResponse.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 public class ProfileUpdateResponse {
     private Long id;
     private String profileUsername;
-    private String email;
     private String name;
     private String lastName;
     private String token;

--- a/src/main/java/com/mypresentpast/backend/model/VerificationToken.java
+++ b/src/main/java/com/mypresentpast/backend/model/VerificationToken.java
@@ -25,4 +25,7 @@ public class VerificationToken {
     @Column(name = "expiry_date", nullable = false)
     private LocalDateTime expiryDate;
 
+    @Column(name = "pending_email")
+    private String pendingEmail;
+
 }

--- a/src/main/java/com/mypresentpast/backend/repository/VerificationTokenRepository.java
+++ b/src/main/java/com/mypresentpast/backend/repository/VerificationTokenRepository.java
@@ -3,12 +3,17 @@ package com.mypresentpast.backend.repository;
 import com.mypresentpast.backend.model.User;
 import com.mypresentpast.backend.model.VerificationToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface VerificationTokenRepository extends JpaRepository<VerificationToken, Long> {
     Optional<VerificationToken> findByToken(String token);
     Optional<VerificationToken> findByUser(User user);
-    void deleteByUser(User user);
 
+    @Modifying
+    @Query("DELETE FROM VerificationToken vt WHERE vt.user = :user")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/mypresentpast/backend/service/ProfileService.java
+++ b/src/main/java/com/mypresentpast/backend/service/ProfileService.java
@@ -2,8 +2,11 @@ package com.mypresentpast.backend.service;
 
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.request.profile.EmailChangeRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
+import jakarta.mail.MessagingException;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -38,6 +41,29 @@ public interface ProfileService {
      * @param request contiene la contraseña actual y la nueva
      */
     void changePassword(Long userId, ChangePasswordRequest request);
+
+    /**
+     * Inicia el flujo de cambio de email: valida contraseña, verifica unicidad del nuevo email
+     * y envía un correo de verificación al nuevo email.
+     *
+     * @param request contiene el nuevo email y la contraseña de confirmación
+     * @return respuesta con mensaje de confirmación del envío
+     * @throws MessagingException si ocurre un error al enviar el correo
+     */
+    ApiResponse initiateEmailChange(EmailChangeRequest request) throws MessagingException;
+
+    /**
+     * Cancela un cambio de email pendiente eliminando el token asociado.
+     */
+    void cancelEmailChange();
+
+    /**
+     * Reenvía el correo de verificación para un cambio de email pendiente.
+     *
+     * @return respuesta con mensaje de confirmación del reenvío
+     * @throws MessagingException si ocurre un error al enviar el correo
+     */
+    ApiResponse resendEmailChange() throws MessagingException;
 
     /**
      * Sube una imagen de avatar del usuario a Cloudinary.

--- a/src/main/java/com/mypresentpast/backend/service/VerificationService.java
+++ b/src/main/java/com/mypresentpast/backend/service/VerificationService.java
@@ -31,6 +31,16 @@ public interface VerificationService {
     ApiResponse validateVerificationToken(String token);
 
     /**
+     * Inicia el flujo de cambio de email: crea un token con el nuevo email pendiente y envía
+     * un correo de verificación a esa dirección. El cambio se aplica solo al confirmar.
+     *
+     * @param user       Usuario que solicita el cambio.
+     * @param newEmail   Nuevo email al que se le enviará la verificación.
+     * @throws MessagingException Si ocurre un error al enviar el correo.
+     */
+    void initiateEmailChange(User user, String newEmail) throws MessagingException;
+
+    /**
      * Reenvía un correo de verificación a un usuario cuyo email no ha sido confirmado aún.
      * Solo funciona si el token existente aún no ha expirado.
      *

--- a/src/main/java/com/mypresentpast/backend/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/AuthServiceImpl.java
@@ -100,7 +100,7 @@ public class AuthServiceImpl implements AuthService {
 
             if (existingUser.isEmailVerified()) {
                 // Caso 1: usuario ya verificado → no se puede registrar de nuevo
-                throw new DataIntegrityViolationException(String.format(MessageBundle.DUPLICATE_EMAIL, request.getEmail()));
+                throw new DataIntegrityViolationException(MessageBundle.DUPLICATE_EMAIL);
             } else {
                 // Caso 2: usuario no verificado
                 VerificationToken vToken = verificationTokenRepository.findByUser(existingUser)

--- a/src/main/java/com/mypresentpast/backend/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/EmailServiceImpl.java
@@ -28,6 +28,7 @@ public class EmailServiceImpl implements EmailService {
             Context context = new Context();
             context.setVariable("name", request.getName());
             context.setVariable("verificationUrl", request.getVerificationUrl());
+            context.setVariable("emailChange", request.isEmailChange());
 
             String contentHtml = templateEngine.process("email", context);
 

--- a/src/main/java/com/mypresentpast/backend/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ProfileServiceImpl.java
@@ -225,7 +225,7 @@ public class ProfileServiceImpl implements ProfileService {
         if (newEmail != null) newEmail = newEmail.toLowerCase();
 
         if (userRepository.existsByEmail(newEmail)) {
-            throw new DataIntegrityViolationException(String.format(MessageBundle.DUPLICATE_EMAIL, newEmail));
+            throw new DataIntegrityViolationException(MessageBundle.DUPLICATE_EMAIL);
         }
 
         verificationService.initiateEmailChange(user, newEmail);

--- a/src/main/java/com/mypresentpast/backend/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/ProfileServiceImpl.java
@@ -2,6 +2,8 @@ package com.mypresentpast.backend.service.impl;
 
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.request.profile.EmailChangeRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
 import com.mypresentpast.backend.enums.PostStatus;
@@ -9,15 +11,19 @@ import com.mypresentpast.backend.exception.BadRequestException;
 import com.mypresentpast.backend.exception.ResourceNotFoundException;
 import com.mypresentpast.backend.exception.UnauthorizedException;
 import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.VerificationToken;
 import com.mypresentpast.backend.repository.FollowRepository;
 import com.mypresentpast.backend.repository.PostRepository;
 import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.repository.VerificationTokenRepository;
 import com.mypresentpast.backend.service.CloudinaryService;
 import com.mypresentpast.backend.service.JwtService;
 import com.mypresentpast.backend.service.ProfileService;
+import com.mypresentpast.backend.service.VerificationService;
 import com.mypresentpast.backend.utils.CommonFunctions;
 import com.mypresentpast.backend.utils.MessageBundle;
 import com.mypresentpast.backend.utils.SecurityUtils;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -44,6 +50,8 @@ public class ProfileServiceImpl implements ProfileService {
     private final PasswordEncoder passwordEncoder;
     private final CloudinaryService cloudinaryService;
     private final JwtService jwtService;
+    private final VerificationTokenRepository tokenRepository;
+    private final VerificationService verificationService;
 
     @Override
     @Transactional(readOnly = true)
@@ -86,7 +94,10 @@ public class ProfileServiceImpl implements ProfileService {
             .profileUsername(user.getProfileUsername())
             .name(user.getName())
             .lastName(user.getLastName())
-            .email(isSelf ? user.getEmail() : null) // Solo incluir email si es perfil propio
+            .email(isSelf ? user.getEmail() : null)
+            .pendingEmail(isSelf ? tokenRepository.findByUser(user)
+                .map(VerificationToken::getPendingEmail)
+                .orElse(null) : null)
             .avatarUrl(user.getAvatar())
             .userType(user.getRole())
             .isSelf(isSelf)
@@ -108,7 +119,6 @@ public class ProfileServiceImpl implements ProfileService {
                         String.format(MessageBundle.USER_NOT_FOUND_WITH_ID, userId)));
 
         // Delegar por campo para reducir complejidad y aislar validaciones
-        applyEmailUpdate(user, request.getEmail());
         applyUsernameUpdate(user, request.getProfileUsername());
         applyNameUpdate(user, request.getName());
         applyLastNameUpdate(user, request.getLastName());
@@ -119,36 +129,15 @@ public class ProfileServiceImpl implements ProfileService {
         // Genera token jwt
         String token = jwtService.getToken(saved);
 
-
         // Mapear a DTO de salida
         return new ProfileUpdateResponse(
                 saved.getId(),
                 saved.getProfileUsername(),
-                saved.getEmail(),
                 saved.getName(),
                 saved.getLastName(),
                 token
         );
 
-    }
-
-    /* Normaliza y actualiza el email si fue enviado */
-    private void applyEmailUpdate(User user, String email) {
-        if (email == null) return; // ignorar campos no enviados (PATCH semantics)
-
-        String newEmail = CommonFunctions.safeTrim(email);
-        if (newEmail != null) newEmail = newEmail.toLowerCase(); // emails en minúsculas
-
-        // No-op si no hay cambios (evita hits innecesarios a BD)
-        if (Objects.equals(newEmail, user.getEmail())) return;
-
-        // Validar unicidad solo si cambia (reduce consultas)
-        if (userRepository.existsByEmail(newEmail)) {
-            throw new DataIntegrityViolationException(String.format(
-                    MessageBundle.DUPLICATE_EMAIL, newEmail));
-        }
-
-        user.setEmail(newEmail);
     }
 
     /* Normaliza y actualiza el username si fue enviado */
@@ -219,6 +208,64 @@ public class ProfileServiceImpl implements ProfileService {
 
         userRepository.save(user);
 
+    }
+
+    @Override
+    public ApiResponse initiateEmailChange(EmailChangeRequest request) throws MessagingException {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format(MessageBundle.USER_NOT_FOUND_WITH_ID, userId)));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BadRequestException(MessageBundle.EMAIL_CHANGE_PASSWORD_REQUIRED);
+        }
+
+        String newEmail = CommonFunctions.safeTrim(request.getNewEmail());
+        if (newEmail != null) newEmail = newEmail.toLowerCase();
+
+        if (userRepository.existsByEmail(newEmail)) {
+            throw new DataIntegrityViolationException(String.format(MessageBundle.DUPLICATE_EMAIL, newEmail));
+        }
+
+        verificationService.initiateEmailChange(user, newEmail);
+
+        return ApiResponse.builder()
+                .message(String.format(MessageBundle.EMAIL_CHANGE_VERIFICATION_SENT, newEmail))
+                .build();
+    }
+
+    @Override
+    public void cancelEmailChange() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format(MessageBundle.USER_NOT_FOUND_WITH_ID, userId)));
+
+        VerificationToken token = tokenRepository.findByUser(user)
+                .filter(t -> t.getPendingEmail() != null)
+                .orElseThrow(() -> new BadRequestException(MessageBundle.EMAIL_CHANGE_PENDING_NOT_FOUND));
+
+        tokenRepository.delete(token);
+    }
+
+    @Override
+    public ApiResponse resendEmailChange() throws MessagingException {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format(MessageBundle.USER_NOT_FOUND_WITH_ID, userId)));
+
+        VerificationToken token = tokenRepository.findByUser(user)
+                .filter(t -> t.getPendingEmail() != null)
+                .orElseThrow(() -> new BadRequestException(MessageBundle.EMAIL_CHANGE_PENDING_NOT_FOUND));
+
+        String pendingEmail = token.getPendingEmail();
+        verificationService.initiateEmailChange(user, pendingEmail);
+
+        return ApiResponse.builder()
+                .message(String.format(MessageBundle.EMAIL_CHANGE_VERIFICATION_SENT, pendingEmail))
+                .build();
     }
 
     @Override

--- a/src/main/java/com/mypresentpast/backend/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/VerificationServiceImpl.java
@@ -46,24 +46,47 @@ public class VerificationServiceImpl implements VerificationService {
 
     @Override
     public ApiResponse validateVerificationToken(String token) {
-        // busca el token
         VerificationToken vToken = tokenRepository.findByToken(token)
                 .orElseThrow(() -> new ResourceNotFoundException(MessageBundle.TOKEN_NOT_FOUND));
-        // valida si no esta vencido
+
         if (vToken.getExpiryDate().isBefore(LocalDateTime.now())) {
             throw new BadRequestException(MessageBundle.TOKEN_EXPIRED);
         }
-        // actualiza el usuario para que el email este verificado y elimina el token
+
         User user = vToken.getUser();
+
+        if (vToken.getPendingEmail() != null) {
+            user.setEmail(vToken.getPendingEmail());
+            userRepository.save(user);
+            tokenRepository.delete(vToken);
+            return ApiResponse.builder().message(MessageBundle.EMAIL_CHANGE_CONFIRMED).build();
+        }
+
         user.setEmailVerified(true);
         userRepository.save(user);
-
-        // El token ya no sirve más
         tokenRepository.delete(vToken);
+        return ApiResponse.builder().message("Email confirmado con éxito").build();
+    }
 
-        return ApiResponse.builder()
-                .message("Email confirmado con éxito")
-                .build();
+    @Override
+    public void initiateEmailChange(User user, String newEmail) throws MessagingException {
+        tokenRepository.deleteByUser(user);
+
+        String tokenValue = UUID.randomUUID().toString();
+        VerificationToken verificationToken = new VerificationToken();
+        verificationToken.setToken(tokenValue);
+        verificationToken.setUser(user);
+        verificationToken.setExpiryDate(LocalDateTime.now().plusHours(EXPIRATION_HOURS));
+        verificationToken.setPendingEmail(newEmail);
+        tokenRepository.save(verificationToken);
+
+        EmailRequest emailRequest = new EmailRequest();
+        emailRequest.setRecipient(newEmail);
+        emailRequest.setSubject("Confirma tu nuevo email en MyPresentPast");
+        emailRequest.setName(user.getName() + " " + user.getLastName());
+        emailRequest.setVerificationUrl("http://localhost:4200/verify-success?token=" + tokenValue);
+        emailRequest.setEmailChange(true);
+        emailService.sendMail(emailRequest);
     }
 
     @Override

--- a/src/main/java/com/mypresentpast/backend/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/com/mypresentpast/backend/service/impl/VerificationServiceImpl.java
@@ -57,6 +57,7 @@ public class VerificationServiceImpl implements VerificationService {
 
         if (vToken.getPendingEmail() != null) {
             user.setEmail(vToken.getPendingEmail());
+            user.setEmailVerified(true);
             userRepository.save(user);
             tokenRepository.delete(vToken);
             return ApiResponse.builder().message(MessageBundle.EMAIL_CHANGE_CONFIRMED).build();

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -17,7 +17,7 @@ public class MessageBundle {
     public static final String PASSWORD_INVALID = "La contraseña debe tener al menos 8 caracteres, una mayúscula, una minúscula y un número.";
     public static final String CURRENT_PASSWORD_INVALID = "Credenciales inválidas.";
     public static final String NEW_PASSWORD_SAME_AS_OLD = "La nueva contraseña no puede ser igual a la actual.";
-    public static final String DUPLICATE_EMAIL = "El email ya está registrado: [%s]";
+    public static final String DUPLICATE_EMAIL = "Este email ya está en uso";
     public static final String DUPLICATE_USERNAME = "El nombre de usuario ya está en uso: %s";
     public static final String LOGIN_FAILED = "Email o contraseña incorrectos";
     public static final String USER_DISABLED = "El usuario no está habilitado para iniciar sesión";
@@ -27,7 +27,7 @@ public class MessageBundle {
         "Se envió un correo de verificación a %s. El cambio se aplicará cuando lo confirmes desde ese correo.";
     public static final String EMAIL_CHANGE_CONFIRMED = "Email actualizado correctamente";
     public static final String EMAIL_CHANGE_PENDING_NOT_FOUND = "No hay ningún cambio de email pendiente";
-    public static final String EMAIL_CHANGE_PASSWORD_REQUIRED = "Debés confirmar tu contraseña para cambiar el email";
+    public static final String EMAIL_CHANGE_PASSWORD_REQUIRED = "Contraseña incorrecta";
 
     // Profile
     public static final String AVATAR_FILE_REQUIRED = "La imagen es obligatoria para actualizar el avatar";

--- a/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
+++ b/src/main/java/com/mypresentpast/backend/utils/MessageBundle.java
@@ -22,6 +22,13 @@ public class MessageBundle {
     public static final String LOGIN_FAILED = "Email o contraseña incorrectos";
     public static final String USER_DISABLED = "El usuario no está habilitado para iniciar sesión";
 
+    // Profile - Email change
+    public static final String EMAIL_CHANGE_VERIFICATION_SENT =
+        "Se envió un correo de verificación a %s. El cambio se aplicará cuando lo confirmes desde ese correo.";
+    public static final String EMAIL_CHANGE_CONFIRMED = "Email actualizado correctamente";
+    public static final String EMAIL_CHANGE_PENDING_NOT_FOUND = "No hay ningún cambio de email pendiente";
+    public static final String EMAIL_CHANGE_PASSWORD_REQUIRED = "Debés confirmar tu contraseña para cambiar el email";
+
     // Profile
     public static final String AVATAR_FILE_REQUIRED = "La imagen es obligatoria para actualizar el avatar";
     public static final String AVATAR_FILE_TOO_LARGE = "La imagen seleccionada supera el tamaño máximo permitido de %d MB.";

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -68,12 +68,21 @@
         <img src="https://res.cloudinary.com/dttgwvnoe/image/upload/v1759452799/logo-my-present-past_boxkdf.jpg" alt="MyPresentPast" width="100" /> <!-- Cambiá por tu logo real -->
     </div>
 
-    <div class="title">Confirma tu correo electrónico</div>
+    <div class="title" th:text="${emailChange} ? 'Confirmá tu nuevo correo electrónico' : 'Confirma tu correo electrónico'">
+        Confirma tu correo electrónico
+    </div>
 
     <div class="message">
         <p>Hola <strong th:text="${name}">Usuario</strong>,</p>
-        <p>Gracias por registrarte en <strong>MyPresentPast</strong>.</p>
-        <p>Haz clic en el botón de abajo para verificar tu dirección de correo electrónico:</p>
+
+        <p th:if="${emailChange}">
+            Recibiste este correo porque solicitaste cambiar el email de tu cuenta en <strong>MyPresentPast</strong>.
+        </p>
+        <p th:unless="${emailChange}">
+            Gracias por registrarte en <strong>MyPresentPast</strong>.
+        </p>
+
+        <p>Hacé clic en el botón de abajo para confirmar tu dirección de correo electrónico:</p>
         <p style="text-align: center;">
             <a th:href="${verificationUrl}"
                style="display: inline-block;
@@ -86,11 +95,18 @@
           text-align: center;
           font-size: 16px;
           margin: 20px auto;
-          border: none;">
+          border: none;"
+               th:text="${emailChange} ? 'Confirmar nuevo email' : 'Confirmar Email'">
                 Confirmar Email
             </a>
         </p>
-        <p>Si no fuiste tú quien se registró, puedes ignorar este correo.</p>
+
+        <p th:if="${emailChange}">
+            Si no fuiste vos quien solicitó este cambio, podés ignorar este correo. Tu email actual no será modificado.
+        </p>
+        <p th:unless="${emailChange}">
+            Si no fuiste vos quien se registró, podés ignorar este correo.
+        </p>
     </div>
 
     <div class="footer">

--- a/src/test/java/com/mypresentpast/backend/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/AuthServiceImplTest.java
@@ -129,7 +129,7 @@ class AuthServiceImplTest {
                 () -> authService.register(request)
         );
 
-        assertEquals(String.format(MessageBundle.DUPLICATE_EMAIL, request.getEmail()), exception.getMessage());
+        assertEquals(MessageBundle.DUPLICATE_EMAIL, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/mypresentpast/backend/service/impl/EmailServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/EmailServiceImplTest.java
@@ -1,0 +1,111 @@
+package com.mypresentpast.backend.service.impl;
+
+import com.mypresentpast.backend.dto.request.EmailRequest;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceImplTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @InjectMocks
+    private EmailServiceImpl emailService;
+
+    private EmailRequest testRequest;
+    private MimeMessage mimeMessage;
+
+    @BeforeEach
+    void setUp() {
+        // MimeMessage real porque MimeMessageHelper lo necesita para funcionar internamente
+        mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+
+        testRequest = new EmailRequest();
+        testRequest.setRecipient("test@example.com");
+        testRequest.setSubject("Verificá tu cuenta");
+        testRequest.setName("Juan");
+        testRequest.setVerificationUrl("https://example.com/verify?token=abc123");
+        testRequest.setEmailChange(false);
+    }
+
+    // Verifica que se envía el correo correctamente y el Context tiene las variables correctas para verificación de cuenta.
+    @Test
+    void sendMail_VerificationEmail_SendsEmailAndSetsContextVariables() {
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email"), any(Context.class))).thenReturn("<html>Verificá tu cuenta</html>");
+
+        assertDoesNotThrow(() -> emailService.sendMail(testRequest));
+
+        ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+        verify(templateEngine).process(eq("email"), contextCaptor.capture());
+        Context capturedContext = contextCaptor.getValue();
+        assertEquals("Juan", capturedContext.getVariable("name"));
+        assertEquals("https://example.com/verify?token=abc123", capturedContext.getVariable("verificationUrl"));
+        assertEquals(false, capturedContext.getVariable("emailChange"));
+
+        verify(javaMailSender).send(mimeMessage);
+    }
+
+    // Verifica que el Context incluye emailChange=true cuando el request corresponde a un cambio de email.
+    @Test
+    void sendMail_EmailChangeRequest_SetsEmailChangeFlagInContext() {
+        testRequest.setEmailChange(true);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email"), any(Context.class))).thenReturn("<html>Cambio de email</html>");
+
+        assertDoesNotThrow(() -> emailService.sendMail(testRequest));
+
+        ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+        verify(templateEngine).process(eq("email"), contextCaptor.capture());
+        assertEquals(true, contextCaptor.getValue().getVariable("emailChange"));
+
+        verify(javaMailSender).send(mimeMessage);
+    }
+
+    // Verifica que si el templateEngine lanza una excepción, se relanza como RuntimeException con el mensaje esperado y no se llama a send().
+    @Test
+    void sendMail_TemplateEngineThrowsException_ThrowsRuntimeException() {
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email"), any(Context.class)))
+                .thenThrow(new RuntimeException("template error"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> emailService.sendMail(testRequest));
+
+        assertTrue(ex.getMessage().startsWith("Error al enviar el correo:"));
+        verify(javaMailSender, never()).send(any(MimeMessage.class));
+    }
+
+    // Verifica que si javaMailSender.send() lanza una excepción, se captura y se relanza como RuntimeException.
+    @Test
+    void sendMail_MailSenderThrowsException_ThrowsRuntimeException() {
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email"), any(Context.class))).thenReturn("<html>content</html>");
+        doThrow(new RuntimeException("mail error")).when(javaMailSender).send(mimeMessage);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> emailService.sendMail(testRequest));
+
+        assertTrue(ex.getMessage().startsWith("Error al enviar el correo:"));
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/ProfileServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/ProfileServiceImplTest.java
@@ -2,19 +2,25 @@ package com.mypresentpast.backend.service.impl;
 
 import com.mypresentpast.backend.dto.request.ProfileUpdateRequest;
 import com.mypresentpast.backend.dto.request.profile.ChangePasswordRequest;
+import com.mypresentpast.backend.dto.request.profile.EmailChangeRequest;
+import com.mypresentpast.backend.dto.response.ApiResponse;
 import com.mypresentpast.backend.dto.response.ProfileResponse;
 import com.mypresentpast.backend.dto.response.ProfileUpdateResponse;
+import com.mypresentpast.backend.utils.MessageBundle;
 import com.mypresentpast.backend.enums.PostStatus;
 import com.mypresentpast.backend.model.UserRole;
 import com.mypresentpast.backend.exception.BadRequestException;
 import com.mypresentpast.backend.exception.ResourceNotFoundException;
 import com.mypresentpast.backend.exception.UnauthorizedException;
 import com.mypresentpast.backend.model.User;
+import com.mypresentpast.backend.model.VerificationToken;
 import com.mypresentpast.backend.repository.FollowRepository;
 import com.mypresentpast.backend.repository.PostRepository;
 import com.mypresentpast.backend.repository.UserRepository;
+import com.mypresentpast.backend.repository.VerificationTokenRepository;
 import com.mypresentpast.backend.service.CloudinaryService;
 import com.mypresentpast.backend.service.JwtService;
+import com.mypresentpast.backend.service.VerificationService;
 import com.mypresentpast.backend.utils.SecurityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,12 +56,17 @@ class ProfileServiceImplTest {
     private CloudinaryService cloudinaryService;
     @Mock
     private JwtService jwtService;
+    @Mock
+    private VerificationTokenRepository tokenRepository;
+    @Mock
+    private VerificationService verificationService;
 
     @InjectMocks
     private ProfileServiceImpl profileService;
 
     // ── Datos de test reutilizables ────────────────────────────────────────
     private User testUser;
+    private VerificationToken testToken;
 
     // ── Setup ──────────────────────────────────────────────────────────────
     @BeforeEach
@@ -71,11 +82,16 @@ class ProfileServiceImplTest {
                 .avatar("https://cloudinary.com/avatar.jpg")
                 .password("encodedPassword")
                 .build();
+
+        testToken = new VerificationToken();
+        testToken.setToken("token-abc123");
+        testToken.setUser(testUser);
+        testToken.setPendingEmail("newemail@example.com");
     }
 
     // ── getProfile ─────────────────────────────────────────────────────────
 
-    // Verifica que el usuario autenticado viendo su propio perfil recibe el email y isSelf=true.
+    // Verifica que el usuario autenticado viendo su propio perfil recibe email, pendingEmail e isSelf=true.
     @Test
     void getProfile_AuthenticatedUserViewingOwnProfile_ReturnsSelfProfileWithEmail() {
         try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
@@ -84,15 +100,17 @@ class ProfileServiceImplTest {
             when(followRepository.countByFolloweeId(1L)).thenReturn(10L);
             when(followRepository.countByFollowerId(1L)).thenReturn(5L);
             when(postRepository.countByAuthorIdAndStatus(1L, PostStatus.ACTIVE)).thenReturn(3L);
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.empty());
 
             ProfileResponse response = profileService.getProfile(1L);
 
             assertNotNull(response);
             assertEquals(1L, response.getId());
             assertEquals("testuser", response.getProfileUsername());
-            assertEquals("test@example.com", response.getEmail()); // email incluido por ser perfil propio
+            assertEquals("test@example.com", response.getEmail());
+            assertNull(response.getPendingEmail());
             assertTrue(response.getIsSelf());
-            assertFalse(response.getFollowing()); // no puede seguirse a sí mismo
+            assertFalse(response.getFollowing());
             assertEquals(10L, response.getFollowerCount());
             assertEquals(5L, response.getFollowingCount());
             assertEquals(3L, response.getPostCount());
@@ -163,21 +181,19 @@ class ProfileServiceImplTest {
 
     // ── updateProfile ──────────────────────────────────────────────────────
 
-    // Verifica que los campos del perfil se actualizan correctamente y se retorna un nuevo JWT.
+    // Verifica que los campos del perfil (sin email) se actualizan correctamente y se retorna un nuevo JWT.
     @Test
     void updateProfile_ValidData_UpdatesFieldsAndReturnsNewToken() {
         try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
             mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
 
             ProfileUpdateRequest request = ProfileUpdateRequest.builder()
-                    .email("new@example.com")
                     .profileUsername("newuser")
                     .name("Jane")
                     .lastName("Smith")
                     .build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-            when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
             when(userRepository.existsByProfileUsername("newuser")).thenReturn(false);
             when(userRepository.save(testUser)).thenReturn(testUser);
             when(jwtService.getToken(testUser)).thenReturn("new-jwt-token");
@@ -187,7 +203,6 @@ class ProfileServiceImplTest {
             assertNotNull(response);
             assertEquals(1L, response.getId());
             assertEquals("newuser", response.getProfileUsername());
-            assertEquals("new@example.com", response.getEmail());
             assertEquals("new-jwt-token", response.getToken());
             verify(userRepository).save(testUser);
         }
@@ -202,22 +217,6 @@ class ProfileServiceImplTest {
 
             ProfileUpdateRequest request = ProfileUpdateRequest.builder().build();
             assertThrows(ResourceNotFoundException.class,
-                    () -> profileService.updateProfile(request));
-
-            verify(userRepository, never()).save(any());
-        }
-    }
-
-    // Verifica que cambiar a un email ya registrado lanza DataIntegrityViolationException.
-    @Test
-    void updateProfile_DuplicateEmail_ThrowsDataIntegrityViolationException() {
-        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
-            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
-            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-            when(userRepository.existsByEmail("taken@example.com")).thenReturn(true);
-
-            ProfileUpdateRequest request = ProfileUpdateRequest.builder().email("taken@example.com").build();
-            assertThrows(DataIntegrityViolationException.class,
                     () -> profileService.updateProfile(request));
 
             verify(userRepository, never()).save(any());
@@ -371,6 +370,194 @@ class ProfileServiceImplTest {
                     () -> profileService.uploadAvatar(mock(MultipartFile.class)));
 
             verify(cloudinaryService, never()).uploadAvatar(any(), any());
+        }
+    }
+
+    // ── initiateEmailChange ────────────────────────────────────────────────
+
+    // Verifica que con password y email válidos se delega al verificationService y se retorna el mensaje correcto.
+    @Test
+    void initiateEmailChange_ValidRequest_DelegatesToVerificationServiceAndReturnsMessage() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(passwordEncoder.matches("plainPassword", "encodedPassword")).thenReturn(true);
+            when(userRepository.existsByEmail("newemail@example.com")).thenReturn(false);
+
+            EmailChangeRequest request = new EmailChangeRequest();
+            request.setNewEmail("newemail@example.com");
+            request.setPassword("plainPassword");
+
+            ApiResponse response = profileService.initiateEmailChange(request);
+
+            String expectedMessage = String.format(MessageBundle.EMAIL_CHANGE_VERIFICATION_SENT, "newemail@example.com");
+            assertEquals(expectedMessage, response.getMessage());
+            verify(verificationService).initiateEmailChange(testUser, "newemail@example.com");
+        }
+    }
+
+    // Verifica que iniciar cambio de email para un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void initiateEmailChange_UserNotFound_ThrowsResourceNotFoundException() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            EmailChangeRequest request = new EmailChangeRequest();
+            request.setNewEmail("newemail@example.com");
+            request.setPassword("plainPassword");
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileService.initiateEmailChange(request));
+
+            verify(verificationService, never()).initiateEmailChange(any(), any());
+        }
+    }
+
+    // Verifica que una contraseña incorrecta lanza BadRequestException sin llegar a verificar el email.
+    @Test
+    void initiateEmailChange_WrongPassword_ThrowsBadRequestException() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
+
+            EmailChangeRequest request = new EmailChangeRequest();
+            request.setNewEmail("newemail@example.com");
+            request.setPassword("wrongPassword");
+
+            assertThrows(BadRequestException.class,
+                    () -> profileService.initiateEmailChange(request));
+
+            verify(verificationService, never()).initiateEmailChange(any(), any());
+        }
+    }
+
+    // Verifica que solicitar un email ya registrado lanza DataIntegrityViolationException.
+    @Test
+    void initiateEmailChange_DuplicateEmail_ThrowsDataIntegrityViolationException() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(passwordEncoder.matches("plainPassword", "encodedPassword")).thenReturn(true);
+            when(userRepository.existsByEmail("taken@example.com")).thenReturn(true);
+
+            EmailChangeRequest request = new EmailChangeRequest();
+            request.setNewEmail("taken@example.com");
+            request.setPassword("plainPassword");
+
+            assertThrows(DataIntegrityViolationException.class,
+                    () -> profileService.initiateEmailChange(request));
+
+            verify(verificationService, never()).initiateEmailChange(any(), any());
+        }
+    }
+
+    // ── cancelEmailChange ──────────────────────────────────────────────────
+
+    // Verifica que cancelar un cambio de email pendiente elimina el token correctamente.
+    @Test
+    void cancelEmailChange_PendingTokenExists_DeletesToken() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.of(testToken));
+
+            profileService.cancelEmailChange();
+
+            verify(tokenRepository).delete(testToken);
+        }
+    }
+
+    // Verifica que cancelar el cambio de email de un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void cancelEmailChange_UserNotFound_ThrowsResourceNotFoundException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileService.cancelEmailChange());
+
+            verify(tokenRepository, never()).delete(any());
+        }
+    }
+
+    // Verifica que cancelar cuando no hay token con email pendiente lanza BadRequestException.
+    @Test
+    void cancelEmailChange_NoPendingEmailToken_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.empty());
+
+            assertThrows(BadRequestException.class,
+                    () -> profileService.cancelEmailChange());
+
+            verify(tokenRepository, never()).delete(any());
+        }
+    }
+
+    // Verifica que un token existente pero sin pendingEmail es filtrado y lanza BadRequestException.
+    @Test
+    void cancelEmailChange_TokenWithNullPendingEmail_ThrowsBadRequestException() {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            testToken.setPendingEmail(null);
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.of(testToken));
+
+            assertThrows(BadRequestException.class,
+                    () -> profileService.cancelEmailChange());
+
+            verify(tokenRepository, never()).delete(any());
+        }
+    }
+
+    // ── resendEmailChange ──────────────────────────────────────────────────
+
+    // Verifica que reenviar la verificación delega al verificationService con el pendingEmail del token y retorna el mensaje correcto.
+    @Test
+    void resendEmailChange_PendingTokenExists_DelegatesToVerificationServiceAndReturnsMessage() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.of(testToken));
+
+            ApiResponse response = profileService.resendEmailChange();
+
+            String expectedMessage = String.format(MessageBundle.EMAIL_CHANGE_VERIFICATION_SENT, "newemail@example.com");
+            assertEquals(expectedMessage, response.getMessage());
+            verify(verificationService).initiateEmailChange(testUser, "newemail@example.com");
+        }
+    }
+
+    // Verifica que reenviar la verificación de un usuario inexistente lanza ResourceNotFoundException.
+    @Test
+    void resendEmailChange_UserNotFound_ThrowsResourceNotFoundException() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileService.resendEmailChange());
+
+            verify(verificationService, never()).initiateEmailChange(any(), any());
+        }
+    }
+
+    // Verifica que reenviar cuando no hay token con email pendiente lanza BadRequestException.
+    @Test
+    void resendEmailChange_NoPendingEmailToken_ThrowsBadRequestException() throws Exception {
+        try (MockedStatic<SecurityUtils> mockedStatic = mockStatic(SecurityUtils.class)) {
+            mockedStatic.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(tokenRepository.findByUser(testUser)).thenReturn(Optional.empty());
+
+            assertThrows(BadRequestException.class,
+                    () -> profileService.resendEmailChange());
+
+            verify(verificationService, never()).initiateEmailChange(any(), any());
         }
     }
 }

--- a/src/test/java/com/mypresentpast/backend/service/impl/RecaptchaServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/RecaptchaServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.mypresentpast.backend.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecaptchaServiceImplTest {
+
+    // restTemplate es private final e inicializado inline, por lo que se captura via mockConstruction
+    private RecaptchaServiceImpl recaptchaService;
+    private RestTemplate restTemplate;
+
+    private static final String TEST_SECRET_KEY = "test-secret-key";
+    private static final String TEST_VERIFY_URL = "https://recaptcha.test.example.com/verify";
+    private static final String TEST_TOKEN = "test-recaptcha-token";
+
+    @BeforeEach
+    void setUp() {
+        try (MockedConstruction<RestTemplate> mocked = mockConstruction(RestTemplate.class)) {
+            recaptchaService = new RecaptchaServiceImpl();
+            restTemplate = mocked.constructed().get(0);
+        }
+        ReflectionTestUtils.setField(recaptchaService, "secretKey", TEST_SECRET_KEY);
+        ReflectionTestUtils.setField(recaptchaService, "verifyUrl", TEST_VERIFY_URL);
+    }
+
+    // Verifica que cuando la API de Google retorna success=true, el método retorna true.
+    @Test
+    void verify_SuccessResponseTrue_ReturnsTrue() {
+        MultiValueMap<String, String> expectedParams = new LinkedMultiValueMap<>();
+        expectedParams.add("secret", TEST_SECRET_KEY);
+        expectedParams.add("response", TEST_TOKEN);
+
+        when(restTemplate.postForObject(TEST_VERIFY_URL, expectedParams, Map.class))
+                .thenReturn(Map.of("success", true));
+
+        boolean result = recaptchaService.verify(TEST_TOKEN);
+
+        assertTrue(result);
+        verify(restTemplate).postForObject(TEST_VERIFY_URL, expectedParams, Map.class);
+    }
+
+    // Verifica que cuando la API retorna success=false, el método retorna false.
+    @Test
+    void verify_SuccessResponseFalse_ReturnsFalse() {
+        MultiValueMap<String, String> expectedParams = new LinkedMultiValueMap<>();
+        expectedParams.add("secret", TEST_SECRET_KEY);
+        expectedParams.add("response", TEST_TOKEN);
+
+        when(restTemplate.postForObject(TEST_VERIFY_URL, expectedParams, Map.class))
+                .thenReturn(Map.of("success", false));
+
+        boolean result = recaptchaService.verify(TEST_TOKEN);
+
+        assertFalse(result);
+        verify(restTemplate).postForObject(TEST_VERIFY_URL, expectedParams, Map.class);
+    }
+
+    // Verifica que cuando postForObject retorna null, el método retorna false sin lanzar excepción.
+    @Test
+    void verify_NullResponse_ReturnsFalse() {
+        MultiValueMap<String, String> expectedParams = new LinkedMultiValueMap<>();
+        expectedParams.add("secret", TEST_SECRET_KEY);
+        expectedParams.add("response", TEST_TOKEN);
+
+        when(restTemplate.postForObject(TEST_VERIFY_URL, expectedParams, Map.class))
+                .thenReturn(null);
+
+        boolean result = recaptchaService.verify(TEST_TOKEN);
+
+        assertFalse(result);
+        verify(restTemplate).postForObject(TEST_VERIFY_URL, expectedParams, Map.class);
+    }
+
+    // Verifica que cuando la respuesta contiene success=null, el método retorna false.
+    @Test
+    void verify_NullSuccessValue_ReturnsFalse() {
+        MultiValueMap<String, String> expectedParams = new LinkedMultiValueMap<>();
+        expectedParams.add("secret", TEST_SECRET_KEY);
+        expectedParams.add("response", TEST_TOKEN);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", null);
+        when(restTemplate.postForObject(TEST_VERIFY_URL, expectedParams, Map.class))
+                .thenReturn(response);
+
+        boolean result = recaptchaService.verify(TEST_TOKEN);
+
+        assertFalse(result);
+        verify(restTemplate).postForObject(TEST_VERIFY_URL, expectedParams, Map.class);
+    }
+
+    // Verifica que cuando restTemplate lanza una excepción de red, el método captura el error y retorna false.
+    @Test
+    void verify_RestTemplateThrowsException_ReturnsFalse() {
+        MultiValueMap<String, String> expectedParams = new LinkedMultiValueMap<>();
+        expectedParams.add("secret", TEST_SECRET_KEY);
+        expectedParams.add("response", TEST_TOKEN);
+
+        when(restTemplate.postForObject(TEST_VERIFY_URL, expectedParams, Map.class))
+                .thenThrow(new RestClientException("Connection refused"));
+
+        boolean result = recaptchaService.verify(TEST_TOKEN);
+
+        assertFalse(result);
+        verify(restTemplate).postForObject(TEST_VERIFY_URL, expectedParams, Map.class);
+    }
+}

--- a/src/test/java/com/mypresentpast/backend/service/impl/VerificationServiceImplTest.java
+++ b/src/test/java/com/mypresentpast/backend/service/impl/VerificationServiceImplTest.java
@@ -188,4 +188,47 @@ class VerificationServiceImplTest {
 
         verify(emailService, never()).sendMail(any());
     }
+
+    // ── validateVerificationToken (flujo email change) ─────────────────────
+
+    // Verifica que un token con pendingEmail aplica el nuevo email al usuario, elimina el token y retorna EMAIL_CHANGE_CONFIRMED.
+    @Test
+    void validateVerificationToken_PendingEmailToken_AppliesEmailChangeAndDeletesToken() {
+        testToken.setPendingEmail("newemail@example.com");
+        when(tokenRepository.findByToken("test-token-123")).thenReturn(Optional.of(testToken));
+
+        ApiResponse response = verificationService.validateVerificationToken("test-token-123");
+
+        assertEquals("newemail@example.com", user.getEmail());
+        verify(userRepository).save(user);
+        verify(tokenRepository).delete(testToken);
+        assertEquals(MessageBundle.EMAIL_CHANGE_CONFIRMED, response.getMessage());
+    }
+
+    // ── initiateEmailChange ────────────────────────────────────────────────
+
+    // Verifica que se elimina el token anterior, se persiste uno nuevo con pendingEmail y se envía el correo con los campos correctos.
+    @Test
+    void initiateEmailChange_ValidRequest_DeletesOldTokenCreatesNewAndSendsEmail() throws MessagingException {
+        ArgumentCaptor<VerificationToken> tokenCaptor = ArgumentCaptor.forClass(VerificationToken.class);
+        ArgumentCaptor<EmailRequest> emailCaptor = ArgumentCaptor.forClass(EmailRequest.class);
+
+        verificationService.initiateEmailChange(user, "newemail@example.com");
+
+        verify(tokenRepository).deleteByUser(user);
+        verify(tokenRepository).save(tokenCaptor.capture());
+        VerificationToken savedToken = tokenCaptor.getValue();
+        assertEquals(user, savedToken.getUser());
+        assertEquals("newemail@example.com", savedToken.getPendingEmail());
+        assertNotNull(savedToken.getToken());
+        assertTrue(savedToken.getExpiryDate().isAfter(LocalDateTime.now().plusHours(23)));
+
+        verify(emailService).sendMail(emailCaptor.capture());
+        EmailRequest sentEmail = emailCaptor.getValue();
+        assertEquals("newemail@example.com", sentEmail.getRecipient());
+        assertEquals("Confirma tu nuevo email en MyPresentPast", sentEmail.getSubject());
+        assertEquals("John Doe", sentEmail.getName());
+        assertTrue(sentEmail.getVerificationUrl().contains(savedToken.getToken()));
+        assertTrue(sentEmail.isEmailChange());
+    }
 }


### PR DESCRIPTION
## Descripción

Implementa el flujo de cambio de email con verificación. Antes, el email podía modificarse directamente desde la edición de perfil sin ninguna confirmación. Ahora el cambio requiere confirmar la contraseña y verificar el nuevo email haciendo clic en un enlace enviado a esa dirección.

## Cambios

**Nuevos endpoints:**
- `POST /me/email-change` — inicia el flujo: valida contraseña, verifica unicidad del nuevo email y envía correo de verificación
- `DELETE /me/pending-email` — cancela un cambio pendiente
- `POST /me/email-change/resend` — reenvía el correo de verificación

**Modelo y persistencia:**
- `VerificationToken` ahora tiene columna `pending_email` para distinguir tokens de registro de tokens de cambio de email
- `validateVerificationToken` bifurca según si el token tiene `pendingEmail`: aplica el cambio o verifica el registro
- `VerificationTokenRepository.deleteByUser` migrado a `@Modifying @Query` para compatibilidad transaccional

**Perfil:**
- Eliminado el campo `email` de `ProfileUpdateRequest` y `ProfileUpdateResponse` (ya no se cambia por edición directa)
- `ProfileResponse` expone `pending_email` para que el frontend pueda mostrar el cambio en curso

**Email:**
- Template diferencia entre correo de registro y correo de cambio de email (título, cuerpo y texto del botón distintos)

**Tests:**
- Nuevos tests unitarios para `initiateEmailChange`, `cancelEmailChange`, `resendEmailChange` en `ProfileServiceImplTest`
- Nuevos tests para el flujo de email change en `VerificationServiceImplTest`
- Nuevo `EmailServiceImplTest` cubriendo envío exitoso, flag `emailChange` y manejo de errores
- Nuevo `RecaptchaServiceImplTest` con 100% de cobertura de ramas